### PR TITLE
Added test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - 3.9
+
+cache: pip
+install:
+  - pip install -r requirements.txt
+
+script:
+  - pytest

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -128,11 +128,12 @@ def get_minio_client(token=None, s3_endpoint=None, bucket=None, access_key=None,
     else:
         if token is None:
             return {"error": f"No Authorization token provided"}, 401
-        response, status_code = get_aws_credential(token=token, endpoint=s3_endpoint, bucket=bucket)
-        if "error" in response:
-            raise Exception(response["error"])
-        access_key = response["access"]
-        secret_key = response["secret"]
+        if access_key is None:
+            response, status_code = get_aws_credential(token=token, endpoint=s3_endpoint, bucket=bucket)
+            if "error" in response:
+                raise Exception(response["error"])
+            access_key = response["access"]
+            secret_key = response["secret"]
 
     from minio import Minio
     if region is None:

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -3,12 +3,18 @@ import re
 import requests
 
 
-## Make sure these env vars are available:
-CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("CANDIG_OPA_SITE_ADMIN_KEY", "site_admin")
+## Env vars for most auth methods:
+CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("OPA_SITE_ADMIN_KEY", "site_admin")
 KEYCLOAK_PUBLIC_URL = os.getenv('KEYCLOAK_PUBLIC_URL', None)
 OPA_URL = os.getenv('OPA_PUBLIC_URL', None)
 VAULT_URL = os.getenv('VAULT_URL', None)
 VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
+
+## Env vars for ingest and other site admin tasks:
+CLIENT_ID = os.getenv("CANDIG_CLIENT_ID", None)
+CLIENT_SECRET = os.getenv("CANDIG_CLIENT_SECRET", None)
+SITE_ADMIN_USER = os.getenv("CANDIG_SITE_ADMIN_USER", None)
+SITE_ADMIN_PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
 
 
 def is_site_admin(request, opa_url=OPA_URL, admin_secret=None, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY):
@@ -76,23 +82,41 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
     return allowed_datasets
 
 
-def get_site_admin_token(keycloak_url=KEYCLOAK_PUBLIC_URL):
-    payload = {
-        "client_id": os.getenv("CANDIG_CLIENT_ID"),
-        "client_secret": os.getenv("CANDIG_CLIENT_SECRET"),
-        "grant_type": "password",
-        "username": os.getenv("CANDIG_SITE_ADMIN_USER"),
-        "password": os.getenv("CANDIG_SITE_ADMIN_PASSWORD"),
-        "scope": "openid"
-    }
-    response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
+def get_aws_credential(request, vault_url=VAULT_URL, endpoint=None, bucket=None, vault_s3_token=VAULT_S3_TOKEN):
+    """
+    Look up S3 credentials in Vault
+    """
+    if vault_s3_token is None:
+        return {"error": f"Vault error: service did not provide VAULT_S3_TOKEN"}, 500
+    if vault_url is None:
+        return {"error": f"Vault error: service did not provide VAULT_URL"}, 500
+    if endpoint is None or bucket is None:
+        return {"error": "Error getting S3 credentials: missing either endpoint or bucket"}, 500
+
+    # eat any http stuff from endpoint:
+    endpoint_parse = re.match(r"https*:\/\/(.+)?", endpoint)
+    if endpoint_parse is not None:
+        endpoint = endpoint_parse.group(1)
+    # if it's any sort of amazon endpoint, it can just be s3.amazonaws.com
+    if "amazonaws.com" in endpoint:
+        endpoint = "s3.amazonaws.com"
+
+    response = requests.get(
+        f"{vault_url}/v1/aws/{endpoint}-{bucket}",
+        headers={
+            "Authorization": f"Bearer {get_auth_token(request)}",
+            "X-Vault-Token": vault_s3_token
+            }
+    )
     if response.status_code == 200:
-        return response.json()["access_token"]
-    else:
-        raise Exception(f"Check for environment variables: {response.text}")
+        return response.json()["data"], response.status_code
+    return {"error": f"Vault error: could not get credential for endpoint {endpoint} and bucket {bucket}"}, response.status_code
 
 
 def get_minio_client(request, s3_endpoint=None, bucket=None, access_key=None, secret_key=None, region=None):
+    """
+    Return a minio client that either refers to the specified endpoint and bucket, or refers to the Minio playbox.
+    """
     if s3_endpoint is None or s3_endpoint == "play.min.io:9000":
         endpoint = "play.min.io:9000"
         access_key="Q3AM3UQ867SPQQA43P2F"
@@ -100,19 +124,7 @@ def get_minio_client(request, s3_endpoint=None, bucket=None, access_key=None, se
         if bucket is None:
             bucket = "candigtest"
     else:
-        # eat any http stuff from endpoint:
-        endpoint_parse = re.match(r"https*:\/\/(.+)?", s3_endpoint)
-        if endpoint_parse is not None:
-            endpoint = endpoint_parse.group(1)
-            
-        # if it's any sort of amazon endpoint, it can just be s3.amazonaws.com
-        if "amazonaws.com" in s3_endpoint:
-            endpoint = "s3.amazonaws.com"
-        else:
-            endpoint = s3_endpoint
-
-        endpoint = s3_endpoint
-        response, status_code = get_aws_credential(request, endpoint=endpoint, bucket=bucket)
+        response, status_code = get_aws_credential(request, endpoint=s3_endpoint, bucket=bucket)
         if "error" in response:
             raise Exception(response["error"])
         access_key = response["access"]
@@ -149,39 +161,50 @@ def get_minio_client(request, s3_endpoint=None, bucket=None, access_key=None, se
 
 
 def get_s3_url(request, s3_endpoint=None, bucket=None, object_id=None, access_key=None, secret_key=None, region=None):
+    """
+    Return a signed URL for an object stored in an S3 bucket.
+    """
     try:
         response = get_minio_client(request, s3_endpoint=s3_endpoint, bucket=bucket, access_key=access_key, secret_key=secret_key, region=region)
         client = response["client"]
-        result = client.stat_object(bucket_name=bucket, object_name=object_id)
-        url = client.presigned_get_object(bucket_name=bucket, object_name=object_id)
+        result = client.stat_object(bucket_name=response["bucket"], object_name=object_id)
+        url = client.presigned_get_object(bucket_name=response["bucket"], object_name=object_id)
     except Exception as e:
         return {"message": str(e)}, 500
     return url, 200
 
 
-def parse_aws_credential(awsfile):
-    # parse the awsfile:
-    access = None
-    secret = None
-    with open(awsfile) as f:
-        lines = f.readlines()
-        while len(lines) > 0 and (access is None or secret is None):
-            line = lines.pop(0)
-            parse_access = re.match(r"(aws_access_key_id|AWSAccessKeyId)\s*=\s*(.+)$", line)
-            if parse_access is not None:
-                access = parse_access.group(2)
-            parse_secret = re.match(r"(aws_secret_access_key|AWSSecretKey)\s*=\s*(.+)$", line)
-            if parse_secret is not None:
-                secret = parse_secret.group(2)
-    if access is None:
-        return {"error": "awsfile did not contain access ID"}
-    if secret is None:
-        return {"error": "awsfile did not contain secret key"}
-    return {"access": access, "secret": secret}
+### Used for ingest only:
+def get_site_admin_token(
+    keycloak_url=KEYCLOAK_PUBLIC_URL,
+    client_id=CLIENT_ID,
+    client_secret=CLIENT_SECRET,
+    username=SITE_ADMIN_USER,
+    password=SITE_ADMIN_PASSWORD
+    ):
+    if keycloak_url is None:
+        return None
+    payload = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "scope": "openid"
+    }
+    response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
+    if response.status_code == 200:
+        return response.json()["access_token"]
+    else:
+        raise Exception(f"Check for environment variables: {response.text}")
 
 
-def store_aws_credential(client, vault_url=VAULT_URL, token=None):
+def store_aws_credential(endpoint=None, bucket=None, access=None, secret=None, keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL):
+    
+    if endpoint is None or bucket is None or access is None or secret is None:
+        return False, f"Credentials not provided for Vault storage"
     # get client token for site_admin:
+    token = get_site_admin_token(keycloak_url=keycloak_url)
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
@@ -196,37 +219,30 @@ def store_aws_credential(client, vault_url=VAULT_URL, token=None):
     if response.status_code == 200:
         client_token = response.json()["auth"]["client_token"]
         headers["X-Vault-Token"] = client_token
-    
+    else:
+        return response.json(), response.status_code
+
+    # eat any http stuff from endpoint:
+    endpoint_parse = re.match(r"https*:\/\/(.+)?", endpoint)
+    if endpoint_parse is not None:
+        endpoint = endpoint_parse.group(1)
+    # if it's any sort of amazon endpoint, it can just be s3.amazonaws.com
+    if "amazonaws.com" in endpoint:
+        endpoint = "s3.amazonaws.com"
+
     # check to see if credential exists:
-    url = f"{vault_url}/v1/aws/{client['endpoint']}-{client['bucket']}"
+    url = f"{vault_url}/v1/aws/{endpoint}-{bucket}"
     response = requests.get(url, headers=headers)
     if response.status_code == 404:
         # add credential:
         body = {
-            "access": client['access'],
-            "secret": client['secret']
+            "access": access,
+            "secret": secret
         }
         response = requests.post(url, headers=headers, json=body)
-    if response.status_code >= 200 and response.status_code < 300:
-        return True, None
-    return False, json.dumps(response.json())
-    
-    
-def get_aws_credential(request, vault_url=VAULT_URL, endpoint=None, bucket=None, vault_s3_token=VAULT_S3_TOKEN):
-    if vault_s3_token is None:
-        return {"error": f"Vault error: service did not provide VAULT_S3_TOKEN"}, 500
-    if vault_url is None:
-        return {"error": f"Vault error: service did not provide VAULT_URL"}, 500
-    response = requests.get(
-        f"{vault_url}/v1/aws/{endpoint}-{bucket}",
-        headers={
-            "Authorization": f"Bearer {get_auth_token(request)}",
-            "X-Vault-Token": vault_s3_token
-            }
-    )
-    if response.status_code == 200:
-        return response.json()["data"], response.status_code
-    return {"error": f"Vault error: could not get credential for endpoint {endpoint} and bucket {bucket}"}, response.status_code
+        if response.status_code >= 200 and response.status_code < 300:
+            return {"message": "Success"}, 200
+    return response.json(), response.status_code
 
 
 if __name__ == "__main__":

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -6,7 +6,7 @@ import requests
 ## Env vars for most auth methods:
 CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("OPA_SITE_ADMIN_KEY", "site_admin")
 KEYCLOAK_PUBLIC_URL = os.getenv('KEYCLOAK_PUBLIC_URL', None)
-OPA_URL = os.getenv('OPA_PUBLIC_URL', None)
+OPA_URL = os.getenv('OPA_URL', None)
 VAULT_URL = os.getenv('VAULT_URL', None)
 VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
 

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -126,6 +126,7 @@ def get_minio_client(token=None, s3_endpoint=None, bucket=None, access_key=None,
         if bucket is None:
             bucket = "candigtest"
     else:
+        endpoint = s3_endpoint
         if token is None:
             return {"error": f"No Authorization token provided"}, 401
         if access_key is None:

--- a/env.sh.template
+++ b/env.sh.template
@@ -1,0 +1,11 @@
+export CANDIG_URL=http://docker.localhost:5080
+export CANDIG_CLIENT_ID=local_candig
+export CANDIG_CLIENT_SECRET=<secret>
+export CANDIG_SITE_ADMIN_USER=user2
+export CANDIG_SITE_ADMIN_PASSWORD=<password>
+export KEYCLOAK_PUBLIC_URL=http://docker.localhost:8080
+export VAULT_URL=http://docker.localhost:5080/vault
+export OPA_URL=http://docker.localhost:5080/policy
+export OPA_SITE_ADMIN_KEY=site_admin
+export VAULT_S3_TOKEN=<token>
+export OPA_SECRET=<secret>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.26.0
 minio==7.1.7
+pytest==7.2.0

--- a/test_auth.py
+++ b/test_auth.py
@@ -1,0 +1,86 @@
+import requests
+import os
+import pytest
+import authx.auth
+import tempfile
+from pathlib import Path
+import warnings
+
+CANDIG_OPA_SITE_ADMIN_KEY = os.getenv("OPA_SITE_ADMIN_KEY", "site_admin")
+KEYCLOAK_PUBLIC_URL = os.getenv('KEYCLOAK_PUBLIC_URL', None)
+OPA_URL = os.getenv('OPA_URL', None)
+OPA_SECRET = os.getenv('OPA_SECRET', None)
+VAULT_URL = os.getenv('VAULT_URL', None)
+VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
+
+
+class FakeRequest:
+    def __init__(self, token=None):
+        token = authx.auth.get_site_admin_token()
+        if token is None:
+            warnings.warn(UserWarning("KEYCLOAK_URL is not set"))
+            token = "testtesttest"
+        self.headers = {"Authorization": f"Bearer {token}"}
+        self.path = f"/htsget/v1/variants/search"
+        self.method = "GET"
+
+def test_site_admin():
+    """
+    If OPA is present, check to see if user2 is a site admin. Otherwise, just assert True.
+    """
+    if OPA_URL is not None:
+        print(f"{OPA_URL} {OPA_SECRET}")
+        assert authx.auth.is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+    else:
+        warnings.warn(UserWarning("OPA_URL is not set"))
+
+
+def test_get_opa_datasets():
+    """
+    Get allowed dataset result from OPA
+    """
+    if OPA_URL is not None:
+        assert len(authx.auth.get_opa_datasets(FakeRequest())) >= 3
+    else:
+        warnings.warn(UserWarning("OPA_URL is not set"))
+
+
+def test_put_aws_credential():
+    """
+    Test adding credentials to Vault
+    """
+    if VAULT_URL is not None:
+        endpoint = "http://test.endpoint"
+        result, status_code = authx.auth.store_aws_credential(endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL)
+        print(result, status_code)
+        assert status_code == 200
+
+        result, status_code = authx.auth.get_aws_credential(FakeRequest(), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=VAULT_S3_TOKEN)
+        print(result, status_code)
+        assert result['secret'] == 'secret'
+    else:
+        warnings.warn(UserWarning("VAULT_URL is not set"))
+        return authx.auth.get_minio_client(FakeRequest())
+
+
+def test_get_s3_url():
+    """
+    Put something in a minio bucket (playbox endpoint) and then get it back
+    """
+    text = "test test"
+
+    fp = tempfile.NamedTemporaryFile()
+    fp.write(bytes(text, 'utf-8'))
+    fp.seek(0)
+    minio = authx.auth.get_minio_client(FakeRequest())
+    filename = Path(fp.name).name
+    minio['client'].put_object(minio['bucket'], filename, fp, Path(fp.name).stat().st_size)
+    fp.close()
+
+    url, status_code = authx.auth.get_s3_url(FakeRequest(), object_id=filename)
+    print(url)
+    assert status_code == 200
+
+    response = requests.get(url)
+    print(response.text)
+    assert response.text == str(text)

--- a/test_auth.py
+++ b/test_auth.py
@@ -55,7 +55,7 @@ def test_put_aws_credential():
         print(result, status_code)
         assert status_code == 200
 
-        result, status_code = authx.auth.get_aws_credential(FakeRequest(), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=VAULT_S3_TOKEN)
+        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=VAULT_S3_TOKEN)
         print(result, status_code)
         assert result['secret'] == 'secret'
     else:
@@ -72,7 +72,7 @@ def test_get_s3_url():
     fp = tempfile.NamedTemporaryFile()
     fp.write(bytes(text, 'utf-8'))
     fp.seek(0)
-    minio = authx.auth.get_minio_client(FakeRequest())
+    minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest()))
     filename = Path(fp.name).name
     minio['client'].put_object(minio['bucket'], filename, fp, Path(fp.name).stat().st_size)
     fp.close()

--- a/test_auth.py
+++ b/test_auth.py
@@ -40,6 +40,7 @@ def test_get_opa_datasets():
     Get allowed dataset result from OPA
     """
     if OPA_URL is not None:
+        # user2 by default has three datasets, open1, open2, and controlled5
         assert len(authx.auth.get_opa_datasets(FakeRequest())) >= 3
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
@@ -60,7 +61,6 @@ def test_put_aws_credential():
         assert result['secret'] == 'secret'
     else:
         warnings.warn(UserWarning("VAULT_URL is not set"))
-        return authx.auth.get_minio_client(FakeRequest())
 
 
 def test_get_s3_url():


### PR DESCRIPTION
I added basic tests via pytest that work either with or without a whole CanDIGv2 stack.

If you run pytest without a running CanDIGv2, tests should pass, but you'll get warnings about things not being set. This is what Travis is currently running.

If you export a set of env vars:
```
export CANDIG_URL=http://docker.localhost:5080
export CANDIG_CLIENT_ID=local_candig
export CANDIG_CLIENT_SECRET=<secret>
export CANDIG_SITE_ADMIN_USER=user2
export CANDIG_SITE_ADMIN_PASSWORD=<password>
export KEYCLOAK_PUBLIC_URL=http://docker.localhost:8080
export VAULT_URL=http://docker.localhost:5080/vault
export OPA_URL=http://docker.localhost:5080/policy
export OPA_SITE_ADMIN_KEY=site_admin
export VAULT_S3_TOKEN=<token>
export OPA_SECRET=<secret>
```
and then run pytest, you should get more robust results.