### PR TITLE
README plus reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ CanDIGv2 has several separate layers that are involved in authentication and aut
 
 Keycloak acts as the identity provider for CanDIGv2. It uses the OpenID protocol to authenticate the user and issue a jwt in the form of a bearer token, identifying the user and their roles to other services. This token is then provided as an Authorization header to other CanDIGv2 services.
 
-`get_access_token` demonstrates the exchange required to get a token. By default, if the proper environment variables are set, it will return a token for the site admin user.
+`get_access_token` demonstrates the exchange required to get a token. 
 
 `get_auth_token` is a convenience method for plucking out the access token from a request's Authorization header.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,39 @@
 # candigv2-authx
-Common CanDIGv2 authorization and authentication code
+Common CanDIGv2 authorization and authentication code.
+
+CanDIGv2 has several separate layers that are involved in authentication and authorization. This repo centralizes the protocols into a single module.
+
+## Authentication: Keycloak
+
+Keycloak acts as the identity provider for CanDIGv2. It uses the OpenID protocol to authenticate the user and issue a jwt in the form of a bearer token, identifying the user and their roles to other services. This token is then provided as an Authorization header to other CanDIGv2 services.
+
+`get_access_token` demonstrates the exchange required to get a token. By default, if the proper environment variables are set, it will return a token for the site admin user.
+
+`get_auth_token` is a convenience method for plucking out the access token from a request's Authorization header.
+
+## Authorization: Tyk
+
+Tyk acts as a proxy redirect service for the other services of CanDIGv2. When a call is made to CanDIGv2, it goes to Tyk first. Tyk validates the bearer token presented and makes sure that it is not expired and is issued by one of the authorized CanDIGv2 sites. If it is valid, it passes the call to the relevant service. When this fails, it returns a 401 "Key not authorised" error.
+
+## Authorization: Opa
+
+Opa does the actual lookup of roles and authorizations for users of CanDIGv2. It contains the information about which datasets a particular user is authorized to access: `get_opa_datasets` uses the email provided in the bearer token to look up the datasets that user is authorized to access.
+
+Opa also confirms if a user is a site admin: `is_site_admin` checks the realm roles for the `CANDIG_OPA_SITE_ADMIN_KEY` and returns True if that role is present in the token.
+
+`OPA_SECRET` is the Opa service's predefined token that authorizes a service to use Opa. It's set as part of the initial setup of the candig-opa container.
+
+## Access to secrets: Vault
+
+Vault acts as the secret store for CanDIGv2. For now, the only store that we use is the key-value store `aws`, for storing and retrieving S3-style credentials. 
+
+Services that require S3 access should have an environment variable `VAULT_S3_TOKEN` that is exchanged with Vault as a header `X-Vault-Token` for authorization to get the credentials. These exchanges are handled by the `get_aws_credential` and `store_aws_credential` methods.
+
+## Access to S3 objects: Minio
+Minio acts as the CanDIGv2 client for S3 access. `get_minio_client` returns a Minio object that can be used with the [Python API](https://min.io/docs/minio/linux/developers/python/API.html). This method, by default, returns an object corresponding to the Minio sandbox instance.
+
+For convenience, `get_s3_url` is a one-stop method for returning a presigned URL to an S3 object.
+
 
 ## To use this library:
 

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -180,16 +180,19 @@ def get_s3_url(request, s3_endpoint=None, bucket=None, object_id=None, access_ke
     return url, 200
 
 
-### Used for ingest only:
-def get_site_admin_token(
+def get_access_token(
     keycloak_url=KEYCLOAK_PUBLIC_URL,
     client_id=CLIENT_ID,
     client_secret=CLIENT_SECRET,
-    username=SITE_ADMIN_USER,
-    password=SITE_ADMIN_PASSWORD
+    username=None,
+    password=None
     ):
     if keycloak_url is None:
-        return None
+        raise Exception("keycloak_url was not provided")
+    if client_id is None or client_secret is None:
+        raise Exception("client_id and client_secret required for token")
+    if username is None or password is None:
+        raise Exception("Username and password required for token")
     payload = {
         "client_id": client_id,
         "client_secret": client_secret,
@@ -205,12 +208,17 @@ def get_site_admin_token(
         raise Exception(f"Check for environment variables: {response.text}")
 
 
+### Used for ingest only:
 def store_aws_credential(endpoint=None, bucket=None, access=None, secret=None, keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL):
-    
     if endpoint is None or bucket is None or access is None or secret is None:
         return False, f"Credentials not provided for Vault storage"
     # get client token for site_admin:
-    token = get_site_admin_token(keycloak_url=keycloak_url)
+    token = get_access_token(
+        keycloak_url=keycloak_url,
+        username=SITE_ADMIN_USER,
+        password=SITE_ADMIN_PASSWORD
+        )
+
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -17,32 +17,6 @@ SITE_ADMIN_USER = os.getenv("CANDIG_SITE_ADMIN_USER", None)
 SITE_ADMIN_PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
 
 
-def is_site_admin(request, opa_url=OPA_URL, admin_secret=None, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY):
-    """
-    Is the user associated with the token a site admin?
-    """
-    if opa_url is None:
-        print("WARNING: AUTHORIZATION IS DISABLED; OPA_URL is not present")
-        return True
-    if "Authorization" in request.headers:
-        token = get_auth_token(request)
-        response = requests.post(
-            opa_url + "/v1/data/idp/" + site_admin_key,
-            headers={
-                "X-Opa": f"{admin_secret}",
-                "Authorization": f"Bearer {token}"
-            },
-            json={
-                "input": {
-                        "token": token
-                    }
-                }
-            )
-        if 'result' in response.json():
-            return True
-    return False
-
-
 def get_auth_token(request):
     """
     Extracts token from request's Authorization header
@@ -108,6 +82,32 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
     response.raise_for_status()
     allowed_datasets = response.json()["result"]
     return allowed_datasets
+
+
+def is_site_admin(request, opa_url=OPA_URL, admin_secret=None, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY):
+    """
+    Is the user associated with the token a site admin?
+    """
+    if opa_url is None:
+        print("WARNING: AUTHORIZATION IS DISABLED; OPA_URL is not present")
+        return True
+    if "Authorization" in request.headers:
+        token = get_auth_token(request)
+        response = requests.post(
+            opa_url + "/v1/data/idp/" + site_admin_key,
+            headers={
+                "X-Opa": f"{admin_secret}",
+                "Authorization": f"Bearer {token}"
+            },
+            json={
+                "input": {
+                        "token": token
+                    }
+                }
+            )
+        if 'result' in response.json():
+            return True
+    return False
 
 
 def get_aws_credential(token=None, vault_url=VAULT_URL, endpoint=None, bucket=None, vault_s3_token=VAULT_S3_TOKEN):

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -53,6 +53,34 @@ def get_auth_token(request):
     return token.split()[1]
 
 
+def get_access_token(
+    keycloak_url=KEYCLOAK_PUBLIC_URL,
+    client_id=CLIENT_ID,
+    client_secret=CLIENT_SECRET,
+    username=None,
+    password=None
+    ):
+    if keycloak_url is None:
+        raise Exception("keycloak_url was not provided")
+    if client_id is None or client_secret is None:
+        raise Exception("client_id and client_secret required for token")
+    if username is None or password is None:
+        raise Exception("Username and password required for token")
+    payload = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "scope": "openid"
+    }
+    response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
+    if response.status_code == 200:
+        return response.json()["access_token"]
+    else:
+        raise Exception(f"Check for environment variables: {response.text}")
+
+
 def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
     """
     Get allowed dataset result from OPA
@@ -178,34 +206,6 @@ def get_s3_url(request, s3_endpoint=None, bucket=None, object_id=None, access_ke
     except Exception as e:
         return {"message": str(e)}, 500
     return url, 200
-
-
-def get_access_token(
-    keycloak_url=KEYCLOAK_PUBLIC_URL,
-    client_id=CLIENT_ID,
-    client_secret=CLIENT_SECRET,
-    username=None,
-    password=None
-    ):
-    if keycloak_url is None:
-        raise Exception("keycloak_url was not provided")
-    if client_id is None or client_secret is None:
-        raise Exception("client_id and client_secret required for token")
-    if username is None or password is None:
-        raise Exception("Username and password required for token")
-    payload = {
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "grant_type": "password",
-        "username": username,
-        "password": password,
-        "scope": "openid"
-    }
-    response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
-    if response.status_code == 200:
-        return response.json()["access_token"]
-    else:
-        raise Exception(f"Check for environment variables: {response.text}")
 
 
 ### Used for ingest only:

--- a/test_auth.py
+++ b/test_auth.py
@@ -12,14 +12,21 @@ OPA_URL = os.getenv('OPA_URL', None)
 OPA_SECRET = os.getenv('OPA_SECRET', None)
 VAULT_URL = os.getenv('VAULT_URL', None)
 VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
+SITE_ADMIN_USER = os.getenv("CANDIG_SITE_ADMIN_USER", None)
+SITE_ADMIN_PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
 
 
 class FakeRequest:
     def __init__(self, token=None):
-        token = authx.auth.get_site_admin_token()
-        if token is None:
+        if KEYCLOAK_PUBLIC_URL is None:
             warnings.warn(UserWarning("KEYCLOAK_URL is not set"))
             token = "testtesttest"
+        else:
+            token = authx.auth.get_access_token(
+                keycloak_url=KEYCLOAK_PUBLIC_URL,
+                username=SITE_ADMIN_USER,
+                password=SITE_ADMIN_PASSWORD
+                )
         self.headers = {"Authorization": f"Bearer {token}"}
         self.path = f"/htsget/v1/variants/search"
         self.method = "GET"


### PR DESCRIPTION
Mostly this is a more comprehensive readme that explains what all the methods are and how they fit in to the larger CanDIGv2 authx scheme.

While I was writing this, I also did a bit of reorganizing, moving methods around into an order that matches the readme. I also realized that get_site_admn_token could really be more generically get_access_token, with the site admin token as a default. It works on my local stack with environment variables set and without.