### PR TITLE
DIG-931: Store S3 endpoint URLs in vault

### DIFF
--- a/authx/auth.py
+++ b/authx/auth.py
@@ -162,9 +162,9 @@ def get_aws_credential(token=None, vault_url=VAULT_URL, endpoint=None, bucket=No
     # clean up endpoint name:
     endpoint = re.sub(r"\W", "_", endpoint)
 
-    vault_token, status_code = get_vault_token(token=token, vault_s3_token=vault_s3_token, vault_url=VAULT_URL)
+    vault_token, status_code = get_vault_token(token=token, vault_s3_token=vault_s3_token, vault_url=vault_url)
     if status_code != 200:
-        return vault_token, status_code
+        return f"get_vault_token failed: {vault_token}", status_code
     response = requests.get(
         f"{vault_url}/v1/aws/{endpoint}-{bucket}",
         headers={
@@ -203,7 +203,7 @@ def store_aws_credential(token=None, endpoint=None, s3_url=None, bucket=None, ac
     endpoint = re.sub(r"\W", "_", endpoint)
     vault_token, status_code = get_vault_token(token=token, vault_s3_token=vault_s3_token, vault_url=vault_url)
     if status_code != 200:
-        return vault_token, status_code
+        return f"get_vault_token failed: {vault_token}", status_code
 
     headers={
         "Authorization": f"Bearer {token}",

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -58,7 +58,7 @@ def get_access_token(
         raise Exception(f"Check for environment variables: {response.text}")
 
 
-def get_opa_datasets(request, opa_url=OPA_URL):
+def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
     """
     Get allowed dataset result from OPA
     Returns array of strings
@@ -78,6 +78,7 @@ def get_opa_datasets(request, opa_url=OPA_URL):
     response = requests.post(
         opa_url + "/v1/data/permissions/datasets",
         headers={
+            "X-Opa": f"{admin_secret}",
             "Authorization": f"Bearer {token}"
         },
         json=body

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -58,7 +58,7 @@ def get_access_token(
         raise Exception(f"Check for environment variables: {response.text}")
 
 
-def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
+def get_opa_datasets(request, opa_url=OPA_URL):
     """
     Get allowed dataset result from OPA
     Returns array of strings
@@ -78,7 +78,6 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
     response = requests.post(
         opa_url + "/v1/data/permissions/datasets",
         headers={
-            "X-Opa": f"{admin_secret}",
             "Authorization": f"Bearer {token}"
         },
         json=body

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -130,6 +130,8 @@ def get_aws_credential(token=None, vault_url=VAULT_URL, endpoint=None, bucket=No
     # if it's any sort of amazon endpoint, it can just be s3.amazonaws.com
     if "amazonaws.com" in endpoint:
         endpoint = "s3.amazonaws.com"
+    # clean up endpoint name:
+    endpoint = re.sub(r"\W", "_", endpoint)
 
     response = requests.get(
         f"{vault_url}/v1/aws/{endpoint}-{bucket}",
@@ -143,7 +145,7 @@ def get_aws_credential(token=None, vault_url=VAULT_URL, endpoint=None, bucket=No
     return {"error": f"Vault error: could not get credential for endpoint {endpoint} and bucket {bucket}"}, response.status_code
 
 
-def store_aws_credential(endpoint=None, bucket=None, access=None, secret=None, keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL):
+def store_aws_credential(endpoint=None, s3_url=None, bucket=None, access=None, secret=None, keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL):
     if endpoint is None or bucket is None or access is None or secret is None:
         return False, f"Credentials not provided for Vault storage"
     # get client token for site_admin:
@@ -177,6 +179,11 @@ def store_aws_credential(endpoint=None, bucket=None, access=None, secret=None, k
     # if it's any sort of amazon endpoint, it can just be s3.amazonaws.com
     if "amazonaws.com" in endpoint:
         endpoint = "s3.amazonaws.com"
+    if s3_url is None:
+        s3_url = endpoint
+        
+    # clean up endpoint name:
+    endpoint = re.sub(r"\W", "_", endpoint)
 
     # check to see if credential exists:
     url = f"{vault_url}/v1/aws/{endpoint}-{bucket}"
@@ -184,6 +191,7 @@ def store_aws_credential(endpoint=None, bucket=None, access=None, secret=None, k
     if response.status_code == 404:
         # add credential:
         body = {
+            "url": url,
             "access": access,
             "secret": secret
         }

--- a/test_auth.py
+++ b/test_auth.py
@@ -46,6 +46,8 @@ def test_site_admin():
     if OPA_URL is not None:
         print(f"{OPA_URL} {OPA_SECRET}")
         assert authx.auth.is_site_admin(FakeRequest(site_admin=True), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+        assert not authx.auth.is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 
@@ -55,10 +57,12 @@ def test_get_opa_datasets():
     Get allowed dataset result from OPA
     """
     if OPA_URL is not None:
-        # user2 by default has three datasets, open1, open2, and controlled5
+        # user1 has controlled4 in its datasets
         user_datasets = authx.auth.get_opa_datasets(FakeRequest())
         print(user_datasets)
         assert "controlled4" in user_datasets
+        
+        # user2 has controlled5 in its datasets
         user_datasets = authx.auth.get_opa_datasets(FakeRequest(site_admin=True))
         print(user_datasets)
         assert "controlled5" in user_datasets

--- a/test_auth.py
+++ b/test_auth.py
@@ -41,7 +41,7 @@ class FakeRequest:
 
 def test_site_admin():
     """
-    If OPA is present, check to see if user2 is a site admin. Otherwise, just assert True.
+    If OPA is present, check to see if SITE_ADMIN_USER is a site admin and that NOT_ADMIN_USER isn't. Otherwise, just assert True.
     """
     if OPA_URL is not None:
         print(f"{OPA_URL} {OPA_SECRET}")

--- a/test_auth.py
+++ b/test_auth.py
@@ -59,13 +59,13 @@ def test_put_aws_credential():
     """
     if VAULT_URL is not None:
         endpoint = "http://test.endpoint"
-        result, status_code = authx.auth.store_aws_credential(endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL)
+        result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest()),endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL)
         print(result, status_code)
         assert status_code == 200
 
         result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=VAULT_S3_TOKEN)
-        print(result, status_code)
         assert result['secret'] == 'secret'
+        assert result['url'] == 'test.endpoint'
     else:
         warnings.warn(UserWarning("VAULT_URL is not set"))
 

--- a/test_auth.py
+++ b/test_auth.py
@@ -57,13 +57,20 @@ def test_get_opa_datasets():
     Get allowed dataset result from OPA
     """
     if OPA_URL is not None:
+        # try to get user1 datasets without OPA_SECRET:
+        try:
+            user_datasets = authx.auth.get_opa_datasets(FakeRequest())
+        except requests.HTTPError as e:
+            # get_opa_datasets should raise an error
+            assert True
+
         # user1 has controlled4 in its datasets
-        user_datasets = authx.auth.get_opa_datasets(FakeRequest())
+        user_datasets = authx.auth.get_opa_datasets(FakeRequest(), admin_secret=OPA_SECRET)
         print(user_datasets)
         assert "controlled4" in user_datasets
         
         # user2 has controlled5 in its datasets
-        user_datasets = authx.auth.get_opa_datasets(FakeRequest(site_admin=True))
+        user_datasets = authx.auth.get_opa_datasets(FakeRequest(site_admin=True), admin_secret=OPA_SECRET)
         print(user_datasets)
         assert "controlled5" in user_datasets
     else:

--- a/test_auth.py
+++ b/test_auth.py
@@ -14,18 +14,26 @@ VAULT_URL = os.getenv('VAULT_URL', None)
 VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
 SITE_ADMIN_USER = os.getenv("CANDIG_SITE_ADMIN_USER", None)
 SITE_ADMIN_PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
+NOT_ADMIN_USER = os.getenv("CANDIG_NOT_ADMIN_USER", None)
+NOT_ADMIN_PASSWORD = os.getenv("CANDIG_NOT_ADMIN_PASSWORD", None)
 
 
 class FakeRequest:
-    def __init__(self, token=None):
+    def __init__(self, token=None, site_admin=False):
         if KEYCLOAK_PUBLIC_URL is None:
             warnings.warn(UserWarning("KEYCLOAK_URL is not set"))
             token = "testtesttest"
-        else:
+        elif site_admin:
             token = authx.auth.get_access_token(
                 keycloak_url=KEYCLOAK_PUBLIC_URL,
                 username=SITE_ADMIN_USER,
                 password=SITE_ADMIN_PASSWORD
+                )
+        else:
+            token = authx.auth.get_access_token(
+                keycloak_url=KEYCLOAK_PUBLIC_URL,
+                username=NOT_ADMIN_USER,
+                password=NOT_ADMIN_PASSWORD
                 )
         self.headers = {"Authorization": f"Bearer {token}"}
         self.path = f"/htsget/v1/variants/search"
@@ -37,7 +45,7 @@ def test_site_admin():
     """
     if OPA_URL is not None:
         print(f"{OPA_URL} {OPA_SECRET}")
-        assert authx.auth.is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+        assert authx.auth.is_site_admin(FakeRequest(site_admin=True), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 
@@ -48,7 +56,12 @@ def test_get_opa_datasets():
     """
     if OPA_URL is not None:
         # user2 by default has three datasets, open1, open2, and controlled5
-        assert len(authx.auth.get_opa_datasets(FakeRequest())) >= 3
+        user_datasets = authx.auth.get_opa_datasets(FakeRequest())
+        print(user_datasets)
+        assert "controlled4" in user_datasets
+        user_datasets = authx.auth.get_opa_datasets(FakeRequest(site_admin=True))
+        print(user_datasets)
+        assert "controlled5" in user_datasets
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 
@@ -59,11 +72,18 @@ def test_put_aws_credential():
     """
     if VAULT_URL is not None:
         endpoint = "http://test.endpoint"
-        result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest()),endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL)
+        # store credential using vault_s3_token and not-site-admin token
+        result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest()),endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", keycloak_url=KEYCLOAK_PUBLIC_URL, vault_url=VAULT_URL, vault_s3_token=VAULT_S3_TOKEN)
         print(result, status_code)
         assert status_code == 200
 
-        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=VAULT_S3_TOKEN)
+        # try getting it with a non-site_admin token
+        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=None)
+        print(result)
+        assert "errors" in result
+        
+        # try getting it with a site_admin token
+        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest(site_admin=True)), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=None)
         assert result['secret'] == 'secret'
         assert result['url'] == 'test.endpoint'
     else:


### PR DESCRIPTION
Cleaned up and refactored the aws credential methods.

* separated out get_vault_token from the aws methods
* endpoint name gets cleaned up to store as a key name in Vault
* endpoint url gets saved as part of the stored Vault value
* updated docstrings
* updated tests to check the changes

Pytest tests should work either with or without docker env vars set (use the env.sh from candigv2-ingest)