### PR TITLE
DIG-970: add methods to authx to add providers to Tyk and Opa

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ CanDIGv2 has several separate layers that are involved in authentication and aut
 
 Keycloak acts as the identity provider for CanDIGv2. It uses the OpenID protocol to authenticate the user and issue a jwt in the form of a bearer token, identifying the user and their roles to other services. This token is then provided as an Authorization header to other CanDIGv2 services.
 
-`get_access_token` demonstrates the exchange required to get a token. 
+`get_access_token` demonstrates the exchange required to get a token.
 
 `get_auth_token` is a convenience method for plucking out the access token from a request's Authorization header.
 
 ## Authorization: Tyk
 
 Tyk acts as a proxy redirect service for the other services of CanDIGv2. When a call is made to CanDIGv2, it goes to Tyk first. Tyk validates the bearer token presented and makes sure that it is not expired and is issued by one of the authorized CanDIGv2 sites. If it is valid, it passes the call to the relevant service. When this fails, it returns a 401 "Key not authorised" error.
+
+`add_provider_to_tyk_api` and `remove_provider_from_tyk_api` add/remove new issuers to a particular API in Tyk.
 
 ## Authorization: Opa
 
@@ -23,9 +25,11 @@ Opa also confirms if a user is a site admin: `is_site_admin` checks the realm ro
 
 `OPA_SECRET` is the Opa service's predefined token that authorizes a service to use Opa. It's set as part of the initial setup of the candig-opa container.
 
+`add_provider_to_opa` and `remove_provider_from_opa` add/remove new issuers to Opa.
+
 ## Access to secrets: Vault
 
-Vault acts as the secret store for CanDIGv2. For now, the only store that we use is the key-value store `aws`, for storing and retrieving S3-style credentials. 
+Vault acts as the secret store for CanDIGv2. For now, the only store that we use is the key-value store `aws`, for storing and retrieving S3-style credentials.
 
 Services that require S3 access should have an environment variable `VAULT_S3_TOKEN` that is exchanged with Vault as a header `X-Vault-Token` for authorization to get the credentials. These exchanges are handled by the `get_aws_credential` and `store_aws_credential` methods.
 

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -380,6 +380,8 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
         new_providers = []
         for p in api_json['openid_options']['providers']:
             if issuer not in p['issuer']:
+                new_providers.append(p)
+            else:
                 if policy_id not in p['client_ids'].values():
                     new_providers.append(p)
 

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -416,7 +416,6 @@ def remove_provider_from_opa(issuer, test_key=None):
         data = response.json()['result']
         new_providers = []
         for p in data:
-            print(f"looking at {p['iss']}")
             if issuer in p['iss']:
                 if test_key is None:
                     new_providers.append(p)

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -365,7 +365,7 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
         api_json['openid_options']['providers'].append(new_provider)
         response = requests.request("PUT", url, headers=headers, json=api_json)
         if response.status_code == 200:
-            response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", headers=headers)
+            response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)
             print("reloaded")
             return requests.request("GET", url, headers=headers)
     return response
@@ -388,7 +388,8 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
         api_json['openid_options']['providers'] = new_providers
         response = requests.request("PUT", url, headers=headers, json=api_json)
         if response.status_code == 200:
-            response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", headers=headers)
+            response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)
+            print("reloaded")
             return requests.request("GET", url, headers=headers)
     return response
 

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -425,7 +425,6 @@ def remove_provider_from_opa(issuer, test_key=None):
                         if p['test'] != test_key:
                             new_providers.append(p)
                     else:
-                        print("hello")
                         new_providers.append(p)
             else:
                 new_providers.append(p)

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -395,7 +395,7 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
 
 
 def add_provider_to_opa(token, issuer, test_key=None):
-    headers = { 'X-Opa': OPA_SECRET, 'Authorization': f"Bearer {get_site_admin_token()}" }
+    headers = { 'X-Opa': OPA_SECRET }
     url = f"{OPA_URL}/v1/data/keys"
     response = requests.get(url, headers=headers)
     if response.status_code == 200:
@@ -415,7 +415,7 @@ def add_provider_to_opa(token, issuer, test_key=None):
 
 
 def remove_provider_from_opa(issuer, test_key=None):
-    headers = { 'X-Opa': OPA_SECRET, 'Authorization': f"Bearer {get_site_admin_token()}" }
+    headers = { 'X-Opa': OPA_SECRET }
     url = f"{OPA_URL}/v1/data/keys"
     response = requests.get(url, headers=headers)
     if response.status_code == 200:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 requests==2.26.0
 minio==7.1.7
 pytest==7.2.0
+PyJWT==2.6.0
+cryptography>=3.4.0

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,15 @@ with open("README.md", "r") as rf:
 
 setuptools.setup(
     name="candigv2_authx",
-    version="v1.0.0",
+    version="v1.1.0",
     author="Daisie Huang",
     python_requires=">=3.7",
     install_requires=[
-        "requests>=2.25.1,<3.0"
+        "requests>=2.25.1,<3.0",
+        "minio>=7.1.7",
+        "pytest==7.2.0",
+        "PyJWT>=2.6.0",
+        "cryptography>=3.4.0"
     ],
 
     description="Common authentication and authorization methods for CanDIGv2",

--- a/test_auth.py
+++ b/test_auth.py
@@ -143,3 +143,15 @@ def test_get_public_s3_url():
     response = requests.get(url)
     print(response.text)
     assert "If you wish to use aspera" in response.text
+
+
+def test_tyk_api():
+    token = authx.auth.get_access_token(
+    keycloak_url=KEYCLOAK_PUBLIC_URL,
+    username=SITE_ADMIN_USER,
+    password=SITE_ADMIN_PASSWORD
+    )
+    response = authx.auth.add_provider_to_tyk_api("91", token, policy_id="testtest")
+    assert response.status_code == 200
+    response = authx.auth.remove_provider_from_tyk_api("91", KEYCLOAK_PUBLIC_URL, policy_id="testtest")
+    assert response.status_code == 200

--- a/test_auth.py
+++ b/test_auth.py
@@ -70,12 +70,12 @@ def test_get_opa_datasets():
         # user1 has controlled4 in its datasets
         user_datasets = authx.auth.get_opa_datasets(FakeRequest(), admin_secret=OPA_SECRET)
         print(user_datasets)
-        assert "controlled4" in user_datasets
+        assert "SYNTHETIC-1" in user_datasets
 
         # user2 has controlled5 in its datasets
         user_datasets = authx.auth.get_opa_datasets(FakeRequest(site_admin=True), admin_secret=OPA_SECRET)
         print(user_datasets)
-        assert "controlled5" in user_datasets
+        assert "SYNTHETIC-2" in user_datasets
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 

--- a/test_auth.py
+++ b/test_auth.py
@@ -57,7 +57,7 @@ def test_add_opa_provider():
         username=SITE_ADMIN_USER,
         password=SITE_ADMIN_PASSWORD
         )
-        response = authx.auth.add_provider_to_opa(token, test_key="testtest")
+        response = authx.auth.add_provider_to_opa(token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", test_key="testtest")
         assert response.status_code == 200
         print(response.json())
     else:
@@ -197,7 +197,7 @@ def test_tyk_api():
     username=SITE_ADMIN_USER,
     password=SITE_ADMIN_PASSWORD
     )
-    response = authx.auth.add_provider_to_tyk_api("91", token, policy_id="testtest")
+    response = authx.auth.add_provider_to_tyk_api("91", token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", policy_id="testtest")
     assert response.status_code == 200
     response = authx.auth.remove_provider_from_tyk_api("91", KEYCLOAK_PUBLIC_URL, policy_id="testtest")
     assert response.status_code == 200

--- a/test_auth.py
+++ b/test_auth.py
@@ -188,6 +188,10 @@ def test_get_public_s3_url():
 
 
 def test_tyk_api():
+    if KEYCLOAK_PUBLIC_URL is None:
+        warnings.warn(UserWarning("KEYCLOAK_URL is not set"))
+        return
+
     token = authx.auth.get_access_token(
     keycloak_url=KEYCLOAK_PUBLIC_URL,
     username=SITE_ADMIN_USER,

--- a/test_auth.py
+++ b/test_auth.py
@@ -42,6 +42,21 @@ class FakeRequest:
         self.path = f"/htsget/v1/variants/search"
         self.method = "GET"
 
+
+def test_add_opa_provider():
+    if OPA_URL is not None:
+        token = authx.auth.get_access_token(
+        keycloak_url=KEYCLOAK_PUBLIC_URL,
+        username=SITE_ADMIN_USER,
+        password=SITE_ADMIN_PASSWORD
+        )
+        response = authx.auth.add_provider_to_opa(token, test_key="testtest")
+        assert response.status_code == 200
+        print(response.json())
+    else:
+        warnings.warn(UserWarning("OPA_URL is not set"))
+
+
 def test_site_admin():
     """
     If OPA is present, check to see if SITE_ADMIN_USER is a site admin and that NOT_ADMIN_USER isn't. Otherwise, just assert True.
@@ -51,6 +66,19 @@ def test_site_admin():
         assert authx.auth.is_site_admin(FakeRequest(site_admin=True), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
         assert not authx.auth.is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
 
+    else:
+        warnings.warn(UserWarning("OPA_URL is not set"))
+
+
+def test_remove_opa_provider():
+    if OPA_URL is not None:
+        token = authx.auth.get_access_token(
+        keycloak_url=KEYCLOAK_PUBLIC_URL,
+        username=SITE_ADMIN_USER,
+        password=SITE_ADMIN_PASSWORD
+        )
+        response = authx.auth.remove_provider_from_opa(KEYCLOAK_PUBLIC_URL, test_key="testtest")
+        assert response.status_code == 200
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 
@@ -157,14 +185,3 @@ def test_tyk_api():
     assert response.status_code == 200
 
 
-def test_opa_provider():
-    token = authx.auth.get_access_token(
-    keycloak_url=KEYCLOAK_PUBLIC_URL,
-    username=SITE_ADMIN_USER,
-    password=SITE_ADMIN_PASSWORD
-    )
-    response = authx.auth.add_provider_to_opa(token, test_key="testtest")
-    assert response.status_code == 200
-    print(response.json())
-    response = authx.auth.remove_provider_from_opa(KEYCLOAK_PUBLIC_URL, test_key="testtest")
-    assert response.status_code == 20

--- a/test_auth.py
+++ b/test_auth.py
@@ -47,6 +47,9 @@ def test_add_opa_provider():
     """
     If OPA is present, try adding a new provider (just ourselves again). Otherwise, just assert True.
     """
+    if KEYCLOAK_PUBLIC_URL is None:
+        warnings.warn(UserWarning("KEYCLOAK_URL is not set"))
+        return
 
     if OPA_URL is not None:
         token = authx.auth.get_access_token(
@@ -78,6 +81,10 @@ def test_remove_opa_provider():
     """
     If OPA is present, remove the test provider we added before. Otherwise, just assert True.
     """
+    if KEYCLOAK_PUBLIC_URL is None:
+        warnings.warn(UserWarning("KEYCLOAK_URL is not set"))
+        return
+
     if OPA_URL is not None:
         token = authx.auth.get_access_token(
         keycloak_url=KEYCLOAK_PUBLIC_URL,

--- a/test_auth.py
+++ b/test_auth.py
@@ -44,6 +44,10 @@ class FakeRequest:
 
 
 def test_add_opa_provider():
+    """
+    If OPA is present, try adding a new provider (just ourselves again). Otherwise, just assert True.
+    """
+
     if OPA_URL is not None:
         token = authx.auth.get_access_token(
         keycloak_url=KEYCLOAK_PUBLIC_URL,
@@ -71,6 +75,9 @@ def test_site_admin():
 
 
 def test_remove_opa_provider():
+    """
+    If OPA is present, remove the test provider we added before. Otherwise, just assert True.
+    """
     if OPA_URL is not None:
         token = authx.auth.get_access_token(
         keycloak_url=KEYCLOAK_PUBLIC_URL,

--- a/test_auth.py
+++ b/test_auth.py
@@ -155,3 +155,16 @@ def test_tyk_api():
     assert response.status_code == 200
     response = authx.auth.remove_provider_from_tyk_api("91", KEYCLOAK_PUBLIC_URL, policy_id="testtest")
     assert response.status_code == 200
+
+
+def test_opa_provider():
+    token = authx.auth.get_access_token(
+    keycloak_url=KEYCLOAK_PUBLIC_URL,
+    username=SITE_ADMIN_USER,
+    password=SITE_ADMIN_PASSWORD
+    )
+    response = authx.auth.add_provider_to_opa(token, test_key="testtest")
+    assert response.status_code == 200
+    print(response.json())
+    response = authx.auth.remove_provider_from_opa(KEYCLOAK_PUBLIC_URL, test_key="testtest")
+    assert response.status_code == 20


### PR DESCRIPTION
You'll need to manually export some environment variables; they're being added to settings.py but that's in a different repo.

```
source ../CanDIGv2/env.sh
export TYK_LOGIN_TARGET_URL=<value in .env>
export TYK_POLICY_ID=<value in .env>
export TYK_SECRET_KEY=<value in tmp/secrets/tyk-secret-key>
```
There is also a bug I noticed in Tyk that will be resolved overall in a future CanDIGv2 PR, but for now, you have to do it manually: go into the Tyk container and rename the api file.
```
docker exec -it candigv2_tyk_1 /bin/bash
# mv apps/api_federation.json apps/91.json
# exit
docker restart candigv2_tyk_1
```


Re-install requirements and then run tests:
```
cd candigv2-authx/
pip install -e .
pytest
```