### PR TITLE
DIG-1178: New AuthX model

### DIFF
--- a/authx/auth.py
+++ b/authx/auth.py
@@ -69,7 +69,7 @@ def get_site_admin_token():
     return get_access_token(username=SITE_ADMIN_USER, password=SITE_ADMIN_PASSWORD)
 
 
-def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
+def get_readable_datasets(request, opa_url=OPA_URL, admin_secret=None):
     """
     Get allowed dataset result from OPA
     Returns array of strings

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -46,7 +46,7 @@ def get_auth_token(request=None, request_data: str=""):
                          "must be provided")
     if request:  # Deprecated request object of unknown type - will assume attributes
         request_object = {
-            "url": request.url,
+            "url": request.path,
             "method": request.method,
             "headers": request.headers,
             "data": request.data
@@ -141,7 +141,7 @@ def get_readable_datasets(request=None, opa_url=OPA_URL, admin_secret=None, requ
                          "must be provided")
     if request:  # Deprecated request object of unknown type - will assume attributes
         request_object = {
-            "url": request.url,
+            "url": request.path,
             "method": request.method,
             "headers": request.headers,
             "data": request.data
@@ -208,7 +208,7 @@ def _is_site_admin(request=None,
                          "must be provided")
     if request:  # Deprecated request object of unknown type - will assume attributes
         request_object = {
-            "url": request.url,
+            "url": request.path,
             "method": request.method,
             "headers": request.headers,
             "data": request.data

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -23,12 +23,24 @@ CLIENT_SECRET = os.getenv("CANDIG_CLIENT_SECRET", None)
 SITE_ADMIN_USER = os.getenv("CANDIG_SITE_ADMIN_USER", None)
 SITE_ADMIN_PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
 
+# A request JSON Object is formatted as follows:
+'''
+{
+    "url": "...",
+    "method": "...",
+    "headers": {
+                 "...": ...,
+                 ...
+    }
+    data: ...
+}
+'''
 
-def get_auth_token(request: requests.Request):
+def get_auth_token(request: dict):
     """
     Extracts token from request's Authorization header
     """
-    token = request.headers['Authorization']
+    token = request["headers"]['Authorization']
     if token is None:
         return None
     return token.split()[1]
@@ -81,8 +93,8 @@ def get_readable_datasets(request: requests.Request, opa_url=OPA_URL, admin_secr
         "input": {
             "token": token,
             "body": {
-                "path": request.url,
-                "method": request.method
+                "path": request["url"],
+                "method": request["method"]
             }
         }
     }
@@ -102,10 +114,10 @@ def is_permissible(request: requests.Request):
     # TODO: Use new OPA functions when implemented
     if _is_site_admin(request):
         return True
-    elif request.method == 'GET':
+    elif request["method"] == 'GET':
         return True
     else:
-        if request.data['program_id'] not in get_readable_datasets(request, admin_secret=OPA_SECRET): return False
+        if request["data"]['program_id'] not in get_readable_datasets(request, admin_secret=OPA_SECRET): return False
         return True
 
 # TODO: Remove once new OPA functions are implemented
@@ -118,7 +130,7 @@ def _is_site_admin(request: requests.Request,
     if opa_url is None:
         print("WARNING: AUTHORIZATION IS DISABLED; OPA_URL is not present")
         return True
-    if "Authorization" in request.headers:
+    if "Authorization" in request["headers"]:
         token = get_auth_token(request)
         response = requests.post(
             opa_url + "/v1/data/idp/" + site_admin_key,

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -174,7 +174,7 @@ def get_readable_datasets(request=None, opa_url=OPA_URL, admin_secret=None, requ
 def is_permissible(request_data: str):
     # TODO: Use new OPA functions when implemented
     request = json.loads(request_data)
-    if is_site_admin(request_data=request_data):
+    if _is_site_admin(request_data=request_data):
         return True
     elif request["method"] == 'GET':
         return True

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -81,7 +81,7 @@ def get_readable_datasets(request: requests.Request, opa_url=OPA_URL, admin_secr
         "input": {
             "token": token,
             "body": {
-                "path": request.path,
+                "path": request.url,
                 "method": request.method
             }
         }

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -125,6 +125,11 @@ def get_refresh_token(keycloak_url=KEYCLOAK_PUBLIC_URL,
 def get_site_admin_token():
     return get_access_token(username=SITE_ADMIN_USER, password=SITE_ADMIN_PASSWORD)
 
+def get_opa_datasets(request=None, opa_url=OPA_URL, admin_secret=None, request_data: str=""):
+    warnings.warn("get_opa_datasets is being renamed to get_readable_datasets."
+                  "See https://candig.atlassian.net/wiki/spaces/CA/pages/725057548/Authx+library+interface",
+                  DeprecationWarning)
+    return get_readable_datasets(request, opa_url, admin_secret, request_data)
 
 def get_readable_datasets(request=None, opa_url=OPA_URL, admin_secret=None, request_data: str=""):
     """

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -98,12 +98,12 @@ def get_readable_datasets(request: requests.Request, opa_url=OPA_URL, admin_secr
     allowed_datasets = response.json()["result"]
     return allowed_datasets
 
-def is_permissible(request: requests.Request, dataset):
+def is_permissible(request: requests.Request, dataset=None):
     # TODO: Use new OPA functions when implemented
     if _is_site_admin(request):
         return True
-    elif request.method == 'POST':
-        return False
+    elif request.method == 'GET':
+        return True
     else:
         if dataset in get_readable_datasets(request, admin_secret=OPA_SECRET):
             return True

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -105,8 +105,7 @@ def is_permissible(request: requests.Request):
     elif request.method == 'GET':
         return True
     else:
-        for entry in request.data:
-            if entry['program_id'] not in get_readable_datasets(request, admin_secret=OPA_SECRET): return False
+        if request.data['program_id'] not in get_readable_datasets(request, admin_secret=OPA_SECRET): return False
         return True
 
 # TODO: Remove once new OPA functions are implemented

--- a/authx/auth.py
+++ b/authx/auth.py
@@ -98,16 +98,16 @@ def get_readable_datasets(request: requests.Request, opa_url=OPA_URL, admin_secr
     allowed_datasets = response.json()["result"]
     return allowed_datasets
 
-def is_permissible(request: requests.Request, dataset=None):
+def is_permissible(request: requests.Request):
     # TODO: Use new OPA functions when implemented
     if _is_site_admin(request):
         return True
     elif request.method == 'GET':
         return True
     else:
-        if dataset in get_readable_datasets(request, admin_secret=OPA_SECRET):
-            return True
-        return False
+        for entry in request.data:
+            if entry['program_id'] not in get_readable_datasets(request, admin_secret=OPA_SECRET): return False
+        return True
 
 # TODO: Remove once new OPA functions are implemented
 def _is_site_admin(request: requests.Request,

--- a/test_auth.py
+++ b/test_auth.py
@@ -146,15 +146,17 @@ def test_get_opa_datasets():
 def test_is_permissible():
     admin_request = FakeRequest(site_admin=True)
     admin_request.method = "POST"
-    assert authx.auth.is_permissible(admin_request, None)
+    assert authx.auth.is_permissible(admin_request)
 
     user_post = FakeRequest(site_admin=False)
     user_post.method = "POST"
-    assert not authx.auth.is_permissible(user_post, None)
+    user_post.data = [{"program_id": "SYNTHETIC-2"}]
+    assert not authx.auth.is_permissible(user_post)
+    user_post.data = [{"program_id": "SYNTHETIC-1"}]
+    assert authx.auth.is_permissible(user_post)
 
     user_get= FakeRequest(site_admin=False)
-    assert authx.auth.is_permissible(user_get, 'SYNTHETIC-1')
-    assert not authx.auth.is_permissible(user_get, 'SYNTHETIC-2')
+    assert authx.auth.is_permissible(user_get)
 
 def test_put_aws_credential():
     """

--- a/test_auth.py
+++ b/test_auth.py
@@ -153,17 +153,20 @@ def test_get_opa_datasets():
         warnings.warn(UserWarning("OPA_URL is not set"))
 
 def test_is_permissible():
-    admin_request = FakeRequest(site_admin=True)
-    admin_request.method = "POST"
-    print(admin_request.getRequest())
-    assert authx.auth.is_permissible(admin_request.getRequest())
+    if OPA_URL:
+        admin_request = FakeRequest(site_admin=True)
+        admin_request.method = "POST"
+        print(admin_request.getRequest())
+        assert authx.auth.is_permissible(admin_request.getRequest())
 
-    user_post = FakeRequest(site_admin=False)
-    user_post.method = "POST"
-    user_post.data = {"program_id": "SYNTHETIC-2"}
-    assert not authx.auth.is_permissible(user_post.getRequest())
-    user_post.data = {"program_id": "SYNTHETIC-1"}
-    assert authx.auth.is_permissible(user_post.getRequest())
+        user_post = FakeRequest(site_admin=False)
+        user_post.method = "POST"
+        user_post.data = {"program_id": "SYNTHETIC-2"}
+        assert not authx.auth.is_permissible(user_post.getRequest())
+        user_post.data = {"program_id": "SYNTHETIC-1"}
+        assert authx.auth.is_permissible(user_post.getRequest())
+    else:
+        warnings.warn(UserWarning("OPA_URL is not set"))
 
     user_get= FakeRequest(site_admin=False)
     assert authx.auth.is_permissible(user_get.getRequest())
@@ -276,11 +279,14 @@ def test_tyk_api():
     assert not found
 
 def test_refresh_token():
-    refresh_token = authx.auth.get_refresh_token(
-        keycloak_url=KEYCLOAK_PUBLIC_URL,
-        username=SITE_ADMIN_USER,
-        password=SITE_ADMIN_PASSWORD
-    )
-    token_from_refresh = authx.auth.get_access_token(keycloak_url=KEYCLOAK_PUBLIC_URL,
-                                        refresh_token=refresh_token)
-    assert token_from_refresh
+    if KEYCLOAK_PUBLIC_URL is not None:
+        refresh_token = authx.auth.get_refresh_token(
+            keycloak_url=KEYCLOAK_PUBLIC_URL,
+            username=SITE_ADMIN_USER,
+            password=SITE_ADMIN_PASSWORD
+        )
+        token_from_refresh = authx.auth.get_access_token(keycloak_url=KEYCLOAK_PUBLIC_URL,
+                                            refresh_token=refresh_token)
+        assert token_from_refresh
+    else:
+        warnings.warn(UserWarning("KEYCLOAK_URL is not set"))

--- a/test_auth.py
+++ b/test_auth.py
@@ -272,3 +272,12 @@ def test_tyk_api():
             found = True
     assert not found
 
+def test_refresh_token():
+    refresh_token = authx.auth.get_refresh_token(
+        keycloak_url=KEYCLOAK_PUBLIC_URL,
+        username=SITE_ADMIN_USER,
+        password=SITE_ADMIN_PASSWORD
+    )
+    token_from_refresh = authx.auth.get_access_token(keycloak_url=KEYCLOAK_PUBLIC_URL,
+                                        refresh_token=refresh_token)
+    assert token_from_refresh

--- a/test_auth.py
+++ b/test_auth.py
@@ -45,6 +45,13 @@ class FakeRequest:
         self.headers = {"Authorization": f"Bearer {token}"}
         self.path = f"/htsget/v1/variants/search"
         self.method = "GET"
+    def getRequest(self):
+        return {
+            "url": self.path,
+            "method": self.method,
+            "headers": self.headers,
+            "data": None
+        }
 
 
 def test_add_opa_provider():
@@ -86,8 +93,8 @@ def test_site_admin():
     """
     if OPA_URL is not None:
         print(f"{OPA_URL} {OPA_SECRET}")
-        assert authx.auth._is_site_admin(FakeRequest(site_admin=True), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
-        assert not authx.auth._is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+        assert authx.auth._is_site_admin(FakeRequest(site_admin=True).getRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+        assert not authx.auth._is_site_admin(FakeRequest().getRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
 
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
@@ -126,36 +133,36 @@ def test_get_opa_datasets():
     if OPA_URL is not None:
         # try to get user1 datasets without OPA_SECRET:
         try:
-            user_datasets = authx.auth.get_readable_datasets(FakeRequest())
+            user_datasets = authx.auth.get_readable_datasets(FakeRequest().getRequest())
         except requests.HTTPError as e:
             # get_readable_datasets should raise an error
             assert True
 
         # user1 has controlled4 in its datasets
-        user_datasets = authx.auth.get_readable_datasets(FakeRequest(), admin_secret=OPA_SECRET)
+        user_datasets = authx.auth.get_readable_datasets(FakeRequest().getRequest(), admin_secret=OPA_SECRET)
         print(user_datasets)
         assert "SYNTHETIC-1" in user_datasets
 
         # user2 has controlled5 in its datasets
-        user_datasets = authx.auth.get_readable_datasets(FakeRequest(site_admin=True), admin_secret=OPA_SECRET)
+        user_datasets = authx.auth.get_readable_datasets(FakeRequest(site_admin=True).getRequest(), admin_secret=OPA_SECRET)
         print(user_datasets)
         assert "SYNTHETIC-2" in user_datasets
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 
 def test_is_permissible():
-    admin_request = FakeRequest(site_admin=True)
-    admin_request.method = "POST"
+    admin_request = FakeRequest(site_admin=True).getRequest()
+    admin_request["method"] = "POST"
     assert authx.auth.is_permissible(admin_request)
 
-    user_post = FakeRequest(site_admin=False)
-    user_post.method = "POST"
-    user_post.data = [{"program_id": "SYNTHETIC-2"}]
+    user_post = FakeRequest(site_admin=False).getRequest()
+    user_post["method"] = "POST"
+    user_post["data"] = {"program_id": "SYNTHETIC-2"}
     assert not authx.auth.is_permissible(user_post)
-    user_post.data = [{"program_id": "SYNTHETIC-1"}]
+    user_post["data"] = {"program_id": "SYNTHETIC-1"}
     assert authx.auth.is_permissible(user_post)
 
-    user_get= FakeRequest(site_admin=False)
+    user_get= FakeRequest(site_admin=False).getRequest()
     assert authx.auth.is_permissible(user_get)
 
 def test_put_aws_credential():
@@ -165,17 +172,17 @@ def test_put_aws_credential():
     if VAULT_URL is not None:
         endpoint = "http://test.endpoint"
         # store credential using vault_s3_token and not-site-admin token
-        result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest()),endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", vault_url=VAULT_URL, vault_s3_token=VAULT_S3_TOKEN)
+        result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest().getRequest()),endpoint=endpoint, bucket="test_bucket", access="test", secret="secret", vault_url=VAULT_URL, vault_s3_token=VAULT_S3_TOKEN)
         print(result, status_code)
         assert status_code == 200
 
         # try getting it with a non-site_admin token
-        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=None)
+        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest().getRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=None)
         print(result)
         assert "errors" in result
 
         # try getting it with a site_admin token
-        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest(site_admin=True)), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=None)
+        result, status_code = authx.auth.get_aws_credential(token=authx.auth.get_auth_token(FakeRequest(site_admin=True).getRequest()), vault_url=VAULT_URL, endpoint=endpoint, bucket="test_bucket", vault_s3_token=None)
         assert result['secret'] == 'secret'
         assert result['url'] == 'test.endpoint'
     else:
@@ -193,20 +200,20 @@ def test_get_s3_url():
     fp.seek(0)
     if MINIO_URL is not None:
         if VAULT_URL is not None:
-            result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest()),endpoint=MINIO_URL, bucket="test", access=MINIO_ACCESS_KEY, secret=MINIO_SECRET_KEY, vault_url=VAULT_URL, vault_s3_token=VAULT_S3_TOKEN)
+            result, status_code = authx.auth.store_aws_credential(token=authx.auth.get_auth_token(FakeRequest().getRequest()),endpoint=MINIO_URL, bucket="test", access=MINIO_ACCESS_KEY, secret=MINIO_SECRET_KEY, vault_url=VAULT_URL, vault_s3_token=VAULT_S3_TOKEN)
             assert result['url'] in MINIO_URL
-            minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest()), s3_endpoint=MINIO_URL, bucket="test")
+            minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest().getRequest()), s3_endpoint=MINIO_URL, bucket="test")
             assert minio['endpoint'] == MINIO_URL
         else:
             warnings.warn(UserWarning("VAULT_URL is not set"))
-        minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest()), s3_endpoint=MINIO_URL, access_key=MINIO_ACCESS_KEY, secret_key=MINIO_SECRET_KEY, bucket="test")
+        minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest().getRequest()), s3_endpoint=MINIO_URL, access_key=MINIO_ACCESS_KEY, secret_key=MINIO_SECRET_KEY, bucket="test")
     else:
-        minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest()))
+        minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest().getRequest()))
     filename = Path(fp.name).name
     minio['client'].put_object(minio['bucket'], filename, fp, Path(fp.name).stat().st_size)
     fp.close()
 
-    url, status_code = authx.auth.get_s3_url(FakeRequest(), object_id=filename, s3_endpoint=minio['endpoint'], bucket=minio['bucket'], access_key=minio['access'], secret_key=minio['secret'])
+    url, status_code = authx.auth.get_s3_url(FakeRequest().getRequest(), object_id=filename, s3_endpoint=minio['endpoint'], bucket=minio['bucket'], access_key=minio['access'], secret_key=minio['secret'])
     print(url)
     assert status_code == 200
 
@@ -217,7 +224,7 @@ def test_get_s3_url():
 
 
 def test_get_public_s3_url():
-    url, status_code = authx.auth.get_s3_url(FakeRequest(), public=True, bucket="1000genomes", s3_endpoint="http://s3.us-east-1.amazonaws.com", object_id="README.ebi_aspera_info", access_key=None, secret_key=None, region="us-east-1")
+    url, status_code = authx.auth.get_s3_url(FakeRequest().getRequest(), public=True, bucket="1000genomes", s3_endpoint="http://s3.us-east-1.amazonaws.com", object_id="README.ebi_aspera_info", access_key=None, secret_key=None, region="us-east-1")
     response = requests.get(url)
     print(response.text)
     assert "If you wish to use aspera" in response.text


### PR DESCRIPTION
- Adds is_permissible(request, dataset) method to validate individual requests
- Changes get_opa_datasets to get_readable_datasets
- Deprecates is_site_admin (still used internally until OPA update is ready)
- Backwards compatible, but warnings are provided for deprecated behavior
- Changes/appends tests appropriately