### PR TITLE
DIG-1169, DIG-1402: Create per-service stores in Vault, use this for Opa

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,25 @@ Opa also confirms if a user is a site admin: `is_site_admin` checks the realm ro
 
 ## Access to secrets: Vault
 
-Vault acts as the secret store for CanDIGv2. For now, the only store that we use is the key-value store `aws`, for storing and retrieving S3-style credentials.
+Vault acts as the secret store for CanDIGv2.
 
 Services that require S3 access should have an environment variable `VAULT_S3_TOKEN` that is exchanged with Vault as a header `X-Vault-Token` for authorization to get the credentials. These exchanges are handled by the `get_aws_credential` and `store_aws_credential` methods.
+
+Every service can be set up to have its own secret store in Vault. Diff your module's setup against the lib/templates folder to see what you need to add to create a service store:
+
+- your-module_setup.sh needs to call `bash $PWD/create_service_store.sh "your-module"`
+- your-module/docker-compose.yml needs to add the following:
+```
+    secrets:
+        - source: vault-approle-token
+          target: vault-approle-token
+    environment:
+        - VAULT_URL="${VAULT_SERVICE_URL}"
+        - SERVICE_NAME="${SERVICE_NAME}"
+```
+
+Once those changes have been made, your service can read and write to its service store using the get_service_store_secret and set_service_store_secret methods.
+
 
 ## Access to S3 objects: Minio
 Minio acts as the CanDIGv2 client for S3 access. `get_minio_client` returns a Minio object that can be used with the [Python API](https://min.io/docs/minio/linux/developers/python/API.html). This method, by default, returns an object corresponding to the Minio sandbox instance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v1.1.0"
+version = "v2.0.0"
 name = "candigv2_authx"
 dependencies = [
     "requests>=2.25.1",

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -474,7 +474,7 @@ def add_provider_to_opa(token, issuer, test_key=None):
                     print(f"{issuer} is already a provider")
     else:
         raise CandigAuthError("couldn't get data from opa store")
-    return response
+    return response["keys"]
 
 
 def remove_provider_from_opa(issuer, test_key=None):
@@ -495,7 +495,7 @@ def remove_provider_from_opa(issuer, test_key=None):
         response, status_code = set_service_store_secret("opa", key="data", value={"keys": new_providers})
     else:
         raise CandigAuthError("couldn't get data from opa store")
-    return response
+    return response["keys"]
 
 
 def get_vault_token_for_service(service=SERVICE_NAME, vault_url=VAULT_URL, approle_token=None, role_id=None, secret_id=None):

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -561,7 +561,7 @@ def set_service_store_secret(service, key=None, value=None, vault_url=VAULT_URL,
         "X-Vault-Token": token
     }
     url = f"{vault_url}/v1/{service}/{key}"
-    response = requests.post(url, headers=headers, json=value)
+    response = requests.post(url, headers=headers, data=value)
     if response.status_code >= 200 and response.status_code < 300:
         response = requests.get(url, headers=headers)
         result = response.json()["data"]
@@ -588,4 +588,4 @@ def get_service_store_secret(service, key=None, vault_url=VAULT_URL, role_id=Non
     if response.status_code == 200:
         result = response.json()["data"]
         return result, 200
-    return response.json(), response.status_code
+    return response.text, response.status_code

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -16,6 +16,7 @@ VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
 TYK_SECRET_KEY = os.getenv("TYK_SECRET_KEY")
 TYK_POLICY_ID = os.getenv("TYK_POLICY_ID")
 TYK_LOGIN_TARGET_URL = os.getenv("TYK_LOGIN_TARGET_URL")
+SERVICE_NAME = os.getenv("SERVICE_NAME")
 
 ## Env vars for ingest and other site admin tasks:
 CLIENT_ID = os.getenv("CANDIG_CLIENT_ID", None)
@@ -494,7 +495,10 @@ def remove_provider_from_opa(issuer, test_key=None):
     return response
 
 
-def get_vault_token_for_service(service, vault_url=VAULT_URL, approle_token=None, role_id=None, secret_id=None):
+def get_vault_token_for_service(service=SERVICE_NAME, vault_url=VAULT_URL, approle_token=None, role_id=None, secret_id=None):
+    """
+    Get this service's vault token
+    """
     # in CanDIGv2 docker stack, approle token should have been passed in
     if approle_token is None:
         with open("/run/secrets/vault-approle-token") as f:
@@ -538,7 +542,7 @@ def get_vault_token_for_service(service, vault_url=VAULT_URL, approle_token=None
 
 def set_service_store_secret(service, key=None, value=None, vault_url=VAULT_URL, role_id=None, secret_id=None, token=None):
     if token is None:
-        token = get_vault_token_for_service(service, vault_url=vault_url, role_id=role_id, secret_id=secret_id)
+        token = get_vault_token_for_service(vault_url=vault_url, role_id=role_id, secret_id=secret_id)
     if token is None:
         return {"message": f"could not obtain token for {service}"}, 400
     if key is None:
@@ -558,7 +562,7 @@ def set_service_store_secret(service, key=None, value=None, vault_url=VAULT_URL,
 
 def get_service_store_secret(service, key=None, vault_url=VAULT_URL, role_id=None, secret_id=None, token=None):
     if token is None:
-        token = get_vault_token_for_service(service, vault_url=vault_url, role_id=role_id, secret_id=secret_id)
+        token = get_vault_token_for_service(vault_url=vault_url, role_id=role_id, secret_id=secret_id)
     if token is None:
         return {"message": f"could not obtain token for {service}"}, 400
     if key is None:

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -499,7 +499,7 @@ def remove_provider_from_opa(issuer, test_key=None):
                         new_providers.append(p)
             else:
                 new_providers.append(p)
-        response, status_code = set_service_store_secret("opa", key="data", value={"keys": new_providers})
+        response, status_code = set_service_store_secret("opa", key="data", value=json.dumps({"keys": new_providers}))
     else:
         raise CandigAuthError("couldn't get data from opa store")
     return response["keys"]

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -570,9 +570,7 @@ def set_service_store_secret(service, key=None, value=None, vault_url=VAULT_URL,
     url = f"{vault_url}/v1/{service}/{key}"
     response = requests.post(url, headers=headers, data=value)
     if response.status_code >= 200 and response.status_code < 300:
-        response = requests.get(url, headers=headers)
-        result = response.json()["data"]
-        return result, 200
+        return get_service_store_secret(service, key, token=token)
     return response.json(), response.status_code
 
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -514,8 +514,11 @@ def get_vault_token_for_service(service=SERVICE_NAME, vault_url=VAULT_URL, appro
 
     # in CanDIGv2 docker stack, roleid should have been passed in
     if role_id is None:
-        with open("/home/candig/roleid") as f:
-            role_id = f.read().strip()
+        try:
+            with open("/home/candig/roleid") as f:
+                role_id = f.read().strip()
+        except Exception as e:
+            raise CandigAuthError(str(e))
     if role_id is None:
         raise CandigAuthError("no role_id found")
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -569,6 +569,9 @@ def set_service_store_secret(service, key=None, value=None, vault_url=VAULT_URL,
     }
     url = f"{vault_url}/v1/{service}/{key}"
     print(f"storing secret of type {str(type(value))}")
+    if ("json" in str(type(value))):
+        print("converting json to string")
+        value = json.dumps(value)
     response = requests.post(url, headers=headers, data=value)
     if response.status_code >= 200 and response.status_code < 300:
         return get_service_store_secret(service, key, token=token)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -568,6 +568,7 @@ def set_service_store_secret(service, key=None, value=None, vault_url=VAULT_URL,
         "X-Vault-Token": token
     }
     url = f"{vault_url}/v1/{service}/{key}"
+    print(f"storing secret of type {str(type(value))}")
     response = requests.post(url, headers=headers, data=value)
     if response.status_code >= 200 and response.status_code < 300:
         return get_service_store_secret(service, key, token=token)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -86,12 +86,15 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
             }
         }
     }
+    headers = {
+        "Authorization": f"Bearer {token}"
+    }
+    if admin_secret is not None:
+        headers["X-Opa"] = f"{admin_secret}"
+
     response = requests.post(
         opa_url + "/v1/data/permissions/datasets",
-        headers={
-            "X-Opa": f"{admin_secret}",
-            "Authorization": f"Bearer {token}"
-        },
+        headers=headers,
         json=body
     )
     response.raise_for_status()
@@ -109,12 +112,14 @@ def is_site_admin(request, opa_url=OPA_URL, admin_secret=None, site_admin_key=CA
         return True
     if "Authorization" in request.headers:
         token = get_auth_token(request)
+        headers = {
+            "Authorization": f"Bearer {token}"
+        }
+        if admin_secret is not None:
+            headers["X-Opa"] = f"{admin_secret}"
         response = requests.post(
             opa_url + "/v1/data/idp/" + site_admin_key,
-            headers={
-                "X-Opa": f"{admin_secret}",
-                "Authorization": f"Bearer {token}"
-            },
+            headers=headers,
             json={
                 "input": {
                         "token": token
@@ -135,12 +140,14 @@ def get_user_email(request, opa_url=OPA_URL, admin_secret=None):
         return None
     if "Authorization" in request.headers:
         token = get_auth_token(request)
+        headers = {
+            "Authorization": f"Bearer {token}"
+        }
+        if admin_secret is not None:
+            headers["X-Opa"] = f"{admin_secret}"
         response = requests.post(
             opa_url + "/v1/data/idp/email",
-            headers={
-                "X-Opa": f"{admin_secret}",
-                "Authorization": f"Bearer {token}"
-            },
+            headers=headers,
             json={
                 "input": {
                         "token": token

--- a/test_auth.py
+++ b/test_auth.py
@@ -23,6 +23,7 @@ MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", None)
 MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", None)
 TYK_SECRET_KEY = os.getenv("TYK_SECRET_KEY")
 TYK_LOGIN_TARGET_URL = os.getenv("TYK_LOGIN_TARGET_URL")
+SERVICE_NAME = os.getenv("SERVICE_NAME")
 
 
 class FakeRequest:
@@ -261,3 +262,19 @@ def test_tyk_api():
             found = True
     assert not found
 
+def test_service_store_secret():
+    """
+    Test adding secrets to Vault
+    """
+    if VAULT_URL is not None:
+        # we can only test the service store of the service we're in:
+        if SERVICE_NAME is None:
+            warnings.warn(UserWarning("SERVICE_NAME is not set"))
+        else:
+            data = {"payload": "test"}
+            response, status_code = authx.auth.set_service_store_secret(SERVICE_NAME, key="testtest", value=data)
+            print(response)
+            assert status_code == 200
+            assert response["payload"] == "test"
+    else:
+        warnings.warn(UserWarning("VAULT_URL is not set"))

--- a/test_auth.py
+++ b/test_auth.py
@@ -64,19 +64,19 @@ def test_add_opa_provider():
         )
         test_key="testtest"
         response = authx.auth.add_provider_to_opa(token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", test_key=test_key)
-        print(response.json())
+        print(response)
         assert response.status_code == 200
         found = False
-        for p in response.json()['result']:
+        for p in response:
             if 'test' in p and p['test'] == test_key:
                 found = True
         assert found
 
         # try adding the same thing again: the count should stay the same
-        count = len(response.json()['result'])
+        count = len(response)
         response = authx.auth.add_provider_to_opa(token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", test_key=test_key)
         assert response.status_code == 200
-        assert len(response.json()['result']) == count
+        assert len(response) == count
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
 
@@ -198,7 +198,8 @@ def test_get_s3_url():
             warnings.warn(UserWarning("VAULT_URL is not set"))
         minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest()), s3_endpoint=MINIO_URL, access_key=MINIO_ACCESS_KEY, secret_key=MINIO_SECRET_KEY, bucket="test")
     else:
-        minio = authx.auth.get_minio_client(token=authx.auth.get_auth_token(FakeRequest()))
+        warnings.warn(UserWarning("MINIO_URL is not set"))
+        return
     filename = Path(fp.name).name
     minio['client'].put_object(minio['bucket'], filename, fp, Path(fp.name).stat().st_size)
     fp.close()

--- a/test_auth.py
+++ b/test_auth.py
@@ -236,7 +236,7 @@ def test_tyk_api():
     policy_id="testtest"
     response = authx.auth.add_provider_to_tyk_api("91", token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", policy_id=policy_id)
     assert response.status_code == 200
-    time.sleep(1) # tyk takes a second to refresh this after reloading
+    time.sleep(5) # tyk takes a second to refresh this after reloading
     url = f"{TYK_LOGIN_TARGET_URL}/tyk/apis/91"
     headers = { "x-tyk-authorization": TYK_SECRET_KEY }
     response = requests.request("GET", url, headers=headers)
@@ -251,11 +251,11 @@ def test_tyk_api():
     count = len(response.json()['openid_options']['providers'])
     response = authx.auth.add_provider_to_tyk_api("91", token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", policy_id=policy_id)
     assert response.status_code == 200
-    time.sleep(1) # tyk takes a second to refresh this after reloading
+    time.sleep(5) # tyk takes a second to refresh this after reloading
     assert len(response.json()['openid_options']['providers']) == count
 
     response = authx.auth.remove_provider_from_tyk_api("91", KEYCLOAK_PUBLIC_URL, policy_id=policy_id)
-    time.sleep(1) # tyk takes a second to refresh this after reloading
+    time.sleep(5) # tyk takes a second to refresh this after reloading
     assert response.status_code == 200
     response = requests.request("GET", url, headers=headers)
     print(response.json()['openid_options']['providers'])

--- a/test_auth.py
+++ b/test_auth.py
@@ -65,7 +65,7 @@ def test_add_opa_provider():
         test_key="testtest"
         response = authx.auth.add_provider_to_opa(token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", test_key=test_key)
         print(response)
-        assert response.status_code == 200
+        assert len(response) > 0
         found = False
         for p in response:
             if 'test' in p and p['test'] == test_key:
@@ -75,7 +75,6 @@ def test_add_opa_provider():
         # try adding the same thing again: the count should stay the same
         count = len(response)
         response = authx.auth.add_provider_to_opa(token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", test_key=test_key)
-        assert response.status_code == 200
         assert len(response) == count
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))
@@ -119,10 +118,13 @@ def test_remove_opa_provider():
         password=SITE_ADMIN_PASSWORD
         )
         test_key="testtest"
+
+        response = authx.auth.add_provider_to_opa(token, f"{KEYCLOAK_PUBLIC_URL}/auth/realms/candig", test_key=test_key)
+        count = len(response)
         response = authx.auth.remove_provider_from_opa(KEYCLOAK_PUBLIC_URL, test_key=test_key)
-        assert response.status_code == 200
+        assert len(response) < count
         found = False
-        for p in response.json()['result']:
+        for p in response:
             if 'test' in p and p['test'] == test_key:
                 found = True
         assert not found


### PR DESCRIPTION
Assume that https://github.com/CanDIG/CanDIGv2/pull/377 is running on your system:

* Added the `get_vault_token_for_service` to automate getting a valid Approle-based token for the service that is calling the method. This only works inside a container that is set up to use vault service stores. It requires the presence of the approle token as a secret, the SERVICE_NAME, and an Approle role id at /home/candig/roleid. (These should be set up as documented in the readme).
* The `set_service_store_secret` and `get_service_store_secret` methods read and write to a named service's store, using the credentials of the container you're executing from.
* Updated the `add_provider_to_opa`/`remove_provider_from_opa` methods to use Opa's service store.

To test: you should be able to do:
```
CanDIGv2$ docker cp env.sh candigv2_opa-runner_1:/app/
CanDIGv2$ docker exec -it candigv2_opa-runner_1 bash
32b982cf8f5d:/app$ source env.sh
32b982cf8f5d:/app$ git clone https://github.com/CanDIG/candigv2-authx.git
32b982cf8f5d:/app$ cd candigv2-authx/
32b982cf8f5d:/app$ git checkout daisieh/vault-opa
32b982cf8f5d:/app$ pip install -e .
32b982cf8f5d:/app$ pytest
```