### PR TITLE
DIG-1382: Create/verify service tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Every service can be set up to have its own secret store in Vault. Diff your mod
         - source: vault-approle-token
           target: vault-approle-token
     environment:
-        - VAULT_URL="${VAULT_SERVICE_URL}"
+        - VAULT_URL="${VAULT_PRIVATE_URL}"
         - SERVICE_NAME="${SERVICE_NAME}"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v2.0.0"
+version = "v2.1.0"
 name = "candigv2_authx"
 dependencies = [
     "requests>=2.25.1",

--- a/test_auth.py
+++ b/test_auth.py
@@ -281,3 +281,18 @@ def test_service_store_secret():
             assert response["payload"] == "test"
     else:
         warnings.warn(UserWarning("VAULT_URL is not set"))
+
+def test_verify_service():
+    """
+    Test verifying the service
+    """
+    if VAULT_URL is not None:
+        # we can only test the service store of the service we're in:
+        if SERVICE_NAME is None:
+            warnings.warn(UserWarning("SERVICE_NAME is not set"))
+        else:
+            token = authx.auth.create_service_token()
+            assert authx.auth.verify_service_token(service=SERVICE_NAME, token=token)
+            assert not authx.auth.verify_service_token(service=SERVICE_NAME, token="foo")
+    else:
+        warnings.warn(UserWarning("VAULT_URL is not set"))


### PR DESCRIPTION
New methods `create_service_token` and `verify_service_token` allow a sending service to add an `X-Service-Token` header to requests and for the receiving service to use that token to verify that the request is truly coming from the sending service.

You'll need to rebuild opa with https://github.com/CanDIG/candig-opa/pull/41 (or the whole stack with https://github.com/CanDIG/CanDIGv2/pull/393), then run the tests:
```
CanDIGv2$ docker cp env.sh candigv2_opa-runner_1:/app/
CanDIGv2$ docker exec -it candigv2_opa-runner_1 bash
32b982cf8f5d:/app$ source env.sh
32b982cf8f5d:/app$ git clone https://github.com/CanDIG/candigv2-authx.git
32b982cf8f5d:/app$ cd candigv2-authx/
32b982cf8f5d:/app$ git checkout daisieh/query-token
32b982cf8f5d:/app$ pip install -e .
32b982cf8f5d:/app$ pytest
```