### PR TITLE
Include metadata in result for get_s3_url

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -351,7 +351,7 @@ def get_s3_url(s3_endpoint=None, bucket=None, object_id=None, access_key=None, s
         url = client.presigned_get_object(bucket_name=response["bucket"], object_name=object_id)
     except Exception as e:
         return {"error": str(e)}, 500
-    return url, 200
+    return {"metadata": result, "url": url}, 200
 
 
 if __name__ == "__main__":

--- a/test_auth.py
+++ b/test_auth.py
@@ -206,19 +206,19 @@ def test_get_s3_url():
     minio['client'].put_object(minio['bucket'], filename, fp, Path(fp.name).stat().st_size)
     fp.close()
 
-    url, status_code = authx.auth.get_s3_url(object_id=filename, s3_endpoint=minio['endpoint'], bucket=minio['bucket'], access_key=minio['access'], secret_key=minio['secret'])
-    print(url)
+    url_obj, status_code = authx.auth.get_s3_url(object_id=filename, s3_endpoint=minio['endpoint'], bucket=minio['bucket'], access_key=minio['access'], secret_key=minio['secret'])
+    print(url_obj["url"])
     assert status_code == 200
 
-    response = requests.get(url)
+    response = requests.get(url_obj["url"])
     print(response.text)
     assert response.text == str(text)
     minio['client'].remove_object(minio['bucket'], filename)
 
 
 def test_get_public_s3_url():
-    url, status_code = authx.auth.get_s3_url(public=True, bucket="1000genomes", s3_endpoint="http://s3.us-east-1.amazonaws.com", object_id="README.ebi_aspera_info", access_key=None, secret_key=None, region="us-east-1")
-    response = requests.get(url)
+    url_obj, status_code = authx.auth.get_s3_url(public=True, bucket="1000genomes", s3_endpoint="http://s3.us-east-1.amazonaws.com", object_id="README.ebi_aspera_info", access_key=None, secret_key=None, region="us-east-1")
+    response = requests.get(url_obj["url"])
     print(response.text)
     assert "If you wish to use aspera" in response.text
 


### PR DESCRIPTION
I apparently had always run `stat_object` and saved the result; I don't know why I didn't pass it back in the response...? 

Anyway, the only module that uses the `get_s3_url` is htsget, and this gets picked up in that PR (https://github.com/CanDIG/htsget_app/pull/287)