### PR TITLE
Pass in refresh token to get access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tyk acts as a proxy redirect service for the other services of CanDIGv2. When a 
 
 Opa does the actual lookup of roles and authorizations for users of CanDIGv2. It contains the information about which datasets a particular user is authorized to access: `get_opa_datasets` uses the email provided in the bearer token to look up the datasets that user is authorized to access.
 
-Opa also confirms if a user is a site admin: `is_site_admin` checks the realm roles for the `CANDIG_OPA_SITE_ADMIN_KEY` and returns True if that role is present in the token.
+Opa also confirms if a user is a site admin: `is_site_admin` checks for whether or not this user is present in Opa's known site_admin role and returns True if so.
 
 `OPA_SECRET` is the Opa service's predefined token that authorizes a service to use Opa. It's set as part of the initial setup of the candig-opa container.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v2.2.1"
+version = "v2.2.2"
 name = "candigv2_authx"
 dependencies = [
     "requests>=2.25.1",

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -39,7 +39,7 @@ def get_auth_token(request):
     return token.split()[1]
 
 
-def get_access_token(
+def get_oauth_response(
     keycloak_url=KEYCLOAK_PUBLIC_URL,
     client_id=CLIENT_ID,
     client_secret=CLIENT_SECRET,
@@ -74,13 +74,40 @@ def get_access_token(
 
     response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
     if response.status_code == 200:
-        return response.json()["access_token"]
+        return response.json()
     else:
         raise CandigAuthError(f"Error obtaining access token: {response.text}")
 
 
-def get_site_admin_token():
-    return get_access_token(username=SITE_ADMIN_USER, password=SITE_ADMIN_PASSWORD)
+def get_access_token(
+    keycloak_url=KEYCLOAK_PUBLIC_URL,
+    client_id=CLIENT_ID,
+    client_secret=CLIENT_SECRET,
+    username=None,
+    password=None,
+    refresh_token=None
+    ):
+
+    result = get_oauth_response(
+        keycloak_url=keycloak_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        username=username,
+        password=password,
+        refresh_token=refresh_token
+        )
+    return result["access_token"]
+
+
+def get_site_admin_token(refresh_token=None):
+    username = SITE_ADMIN_USER
+    password = SITE_ADMIN_PASSWORD
+    if username is None:
+        username = input("Enter username: ")
+    if password is None:
+        password = input("Enter password: ")
+
+    return get_access_token(username=username, password=password, refresh_token=refresh_token)
 
 
 def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -75,6 +75,8 @@ def get_oauth_response(
     response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
     if response.status_code == 200:
         return response.json()
+    elif response.status_code == 400:
+        return {"error": response.text}
     else:
         raise CandigAuthError(f"Error obtaining access token: {response.text}")
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -21,8 +21,6 @@ SERVICE_NAME = os.getenv("SERVICE_NAME")
 ## Env vars for ingest and other site admin tasks:
 CLIENT_ID = os.getenv("CANDIG_CLIENT_ID", None)
 CLIENT_SECRET = os.getenv("CANDIG_CLIENT_SECRET", None)
-SITE_ADMIN_USER = os.getenv("CANDIG_SITE_ADMIN_USER", None)
-SITE_ADMIN_PASSWORD = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
 
 
 class CandigAuthError(Exception):
@@ -102,8 +100,8 @@ def get_access_token(
 
 
 def get_site_admin_token(refresh_token=None):
-    username = SITE_ADMIN_USER
-    password = SITE_ADMIN_PASSWORD
+    username = os.getenv("CANDIG_SITE_ADMIN_USER", None)
+    password = os.getenv("CANDIG_SITE_ADMIN_PASSWORD", None)
     if username is None:
         username = input("Enter username: ")
     if password is None:
@@ -424,10 +422,7 @@ def get_s3_url(s3_endpoint=None, bucket=None, object_id=None, access_key=None, s
 
 if __name__ == "__main__":
     print(get_access_token(
-        keycloak_url=KEYCLOAK_PUBLIC_URL,
-        username=SITE_ADMIN_USER,
-        password=SITE_ADMIN_PASSWORD
-        ))
+        keycloak_url=KEYCLOAK_PUBLIC_URL))
 
 
 def decode_verify_token(token, issuer):

--- a/test_auth.py
+++ b/test_auth.py
@@ -86,8 +86,8 @@ def test_site_admin():
     """
     if OPA_URL is not None:
         print(f"{OPA_URL} {OPA_SECRET}")
-        assert authx.auth.is_site_admin(FakeRequest(site_admin=True), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
-        assert not authx.auth.is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET, site_admin_key=CANDIG_OPA_SITE_ADMIN_KEY)
+        assert authx.auth.is_site_admin(FakeRequest(site_admin=True), opa_url=OPA_URL, admin_secret=OPA_SECRET)
+        assert not authx.auth.is_site_admin(FakeRequest(), opa_url=OPA_URL, admin_secret=OPA_SECRET)
 
     else:
         warnings.warn(UserWarning("OPA_URL is not set"))


### PR DESCRIPTION
Allow user to pass in refresh token to exchange for access token. Also break out the ability to get the whole oauth response instead of just the token.

No change to existing functionality, but new bits will be tested in the new site_admin_token.py.