### PR TITLE
DIG-1653: aws credentials stored as vault secret in ingest's store

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Opa also confirms if a user is a site admin: `is_site_admin` checks for whether 
 
 Vault acts as the secret store for CanDIGv2.
 
-Services that require S3 access should have an environment variable `VAULT_S3_TOKEN` that is exchanged with Vault as a header `X-Vault-Token` for authorization to get the credentials. These exchanges are handled by the `get_aws_credential` and `store_aws_credential` methods.
-
 Every service can be set up to have its own secret store in Vault. Diff your module's setup against the lib/templates folder to see what you need to add to create a service store:
 
 - your-module_setup.sh needs to call `bash $PWD/create_service_store.sh "your-module"`
@@ -47,6 +45,8 @@ Every service can be set up to have its own secret store in Vault. Diff your mod
 ```
 
 Once those changes have been made, your service can read and write to its service store using the get_service_store_secret and set_service_store_secret methods.
+
+Services that require S3 access need to be authorized in `vault_setup.sh` to access candig-ingest's `aws` secret store. Once that authorization is set up, the service can use the get_aws_credential,
 
 
 ## Access to S3 objects: Minio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v2.3.0"
+version = "v2.4.0"
 name = "candigv2_authx"
 dependencies = [
     "requests>=2.25.1",

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -234,7 +234,7 @@ def get_user_email(request, opa_url=OPA_URL, admin_secret=OPA_SECRET):
 
 def get_aws_credential(endpoint=None, bucket=None, vault_url=VAULT_URL):
     """
-    Look up S3 credentials in Vault.
+    Look up S3 credentials in Vault. Executing service must be authorized to access candig-ingest's `/aws` Vault secret path.
     Returns credential object, status code
     """
     if endpoint is None or bucket is None:
@@ -260,7 +260,7 @@ def get_aws_credential(endpoint=None, bucket=None, vault_url=VAULT_URL):
 
 def store_aws_credential(endpoint=None, s3_url=None, bucket=None, access=None, secret=None, vault_url=VAULT_URL):
     """
-    Store aws credentials in Vault.
+    Store aws credentials in Vault. Executing service must be authorized to write to candig-ingest's `/aws` Vault secret path.
     Returns credential object, status code
     """
     if endpoint is None or bucket is None or access is None or secret is None:
@@ -298,7 +298,7 @@ def store_aws_credential(endpoint=None, s3_url=None, bucket=None, access=None, s
 
 def remove_aws_credential(endpoint=None, bucket=None, vault_url=VAULT_URL):
     """
-    Delete S3 credentials in Vault.
+    Delete S3 credentials in Vault. Executing service must be authorized to delete from candig-ingest's `/aws` Vault secret path.
     Returns credential object, status code
     """
     if endpoint is None or bucket is None:

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -232,35 +232,6 @@ def get_user_email(request, opa_url=OPA_URL, admin_secret=OPA_SECRET):
     return None
 
 
-def get_vault_token(token=None, vault_s3_token=None, vault_url=VAULT_URL):
-    """
-    Given a known vault_s3_token, exchange for a valid X-Vault-Token.
-    Returns token, status_code
-    """
-    if vault_url is None:
-        return {"error": f"Vault error: service did not provide VAULT_URL"}, 500
-    if vault_s3_token is None:
-        if token is None:
-            return {"error": f"Vault error: service did not provide VAULT_S3_TOKEN"}, 500
-        headers = {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-            "charset": "utf-8"
-        }
-        body = {
-            "jwt": token,
-            "role": "site_admin"
-        }
-        url = f"{vault_url}/v1/auth/jwt/login"
-        response = requests.post(url, json=body, headers=headers)
-        if response.status_code == 200:
-            client_token = response.json()["auth"]["client_token"]
-            return client_token, 200
-        else:
-            return response.json(), response.status_code
-    return vault_s3_token, 200
-
-
 def get_aws_credential(endpoint=None, bucket=None, vault_url=VAULT_URL):
     """
     Look up S3 credentials in Vault.

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -219,7 +219,7 @@ def get_user_email(request, opa_url=OPA_URL, admin_secret=OPA_SECRET):
         if admin_secret is not None:
             headers["X-Opa"] = f"{admin_secret}"
         response = requests.post(
-            opa_url + f"/v1/data/idp/{CANDIG_USER_KEY}",
+            opa_url + f"/v1/data/idp/user_key",
             headers=headers,
             json={
                 "input": {


### PR DESCRIPTION
These changes are tested in integration test test_aws_credentials in https://github.com/CanDIG/CanDIGv2/pull/592.