### PR TITLE
Allow replacing values for Opa and Tyk in case of IdP update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v2.4.2"
+version = "v2.4.3"
 name = "candigv2_authx"
 dependencies = [
     "requests>=2.25.1",

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -457,10 +457,10 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
                 break
         if not found:
             api_json['openid_options']['providers'].append(new_provider)
-            response = requests.request("PUT", url, headers=headers, json=api_json)
-            if response.status_code == 200:
-                response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)
-                return requests.request("GET", url, headers=headers)
+        response = requests.request("PUT", url, headers=headers, json=api_json)
+        if response.status_code == 200:
+            response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)
+            return requests.request("GET", url, headers=headers)
     return response
 
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -448,15 +448,17 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
         api_json = response.json()
         # check to see if it's already here:
         found = False
-        for s in api_json['openid_options']['providers']:
+        for i in range(0, len(api_json['openid_options']['providers'])):
+            s = api_json['openid_options']['providers'][i]
             if json.dumps(s, sort_keys=True) == json.dumps(new_provider, sort_keys=True):
                 found = True
+                api_json['openid_options']['providers'][i] = new_provider
+                break
         if not found:
             api_json['openid_options']['providers'].append(new_provider)
             response = requests.request("PUT", url, headers=headers, json=api_json)
             if response.status_code == 200:
                 response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)
-                print("reloaded")
                 return requests.request("GET", url, headers=headers)
     return response
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -12,7 +12,6 @@ import getpass
 KEYCLOAK_PUBLIC_URL = os.getenv('KEYCLOAK_PUBLIC_URL', None)
 OPA_URL = os.getenv('OPA_URL', None)
 VAULT_URL = os.getenv('VAULT_URL', None)
-VAULT_S3_TOKEN = os.getenv('VAULT_S3_TOKEN', None)
 TYK_SECRET_KEY = os.getenv("TYK_SECRET_KEY")
 TYK_POLICY_ID = os.getenv("TYK_POLICY_ID")
 TYK_LOGIN_TARGET_URL = os.getenv("TYK_LOGIN_TARGET_URL")

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -196,29 +196,30 @@ def is_action_allowed_for_program(token, method=None, path=None, program=None, o
     return False
 
 
-def get_user_id(request, opa_url=OPA_URL):
+def get_user_id(request, token=None, opa_url=OPA_URL):
     """
     Returns the ID (key defined in .env as CANDIG_USER_KEY) associated with the user.
     """
     if opa_url is None:
         print("WARNING: AUTHORIZATION IS DISABLED; OPA_URL is not present")
         return None
-    if "Authorization" in request.headers:
-        token = get_auth_token(request)
-        headers = {
-            "Authorization": f"Bearer {token}"
-        }
-        response = requests.post(
-            opa_url + f"/v1/data/idp/user_key",
-            headers=headers,
-            json={
-                "input": {
-                        "token": token
-                    }
+    if token is None:
+        if "Authorization" in request.headers:
+            token = get_auth_token(request)
+    headers = {
+        "Authorization": f"Bearer {token}"
+    }
+    response = requests.post(
+        opa_url + f"/v1/data/idp/user_key",
+        headers=headers,
+        json={
+            "input": {
+                    "token": token
                 }
-            )
-        if 'result' in response.json():
-            return response.json()['result']
+            }
+        )
+    if 'result' in response.json():
+        return response.json()['result']
     return None
 
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -506,7 +506,8 @@ def add_provider_to_opa(token, issuer, test_key=None):
     if status_code == 200:
         # check to see if it's already here:
         found = False
-        for s in response["keys"]:
+        for i in range(0, len(response["keys"])):
+            s = response["keys"][i]
             if s['iss'] == new_provider['iss']:
                 found = True
                 if 'test' in new_provider:
@@ -515,10 +516,12 @@ def add_provider_to_opa(token, issuer, test_key=None):
                     else:
                         if s['test'] != new_provider['test']:
                             found = False # not the same because they have different test keys
+                if found:
+                    # replace with the new provider data
+                    response["keys"][i] = new_provider
+                    break
         if not found:
             response["keys"].append(new_provider)
-        else:
-            print(f"{issuer} is already a provider")
     else:
         response = {
             "keys": [new_provider]


### PR DESCRIPTION
In case someone needs to reset the values for Opa and Tyk because, for example, your own keycloak has been reset and you have new values, we should allow the values to be updated.

In addition, you can now call get_user_id with no request and just a token value (this is useful for testing).

None of these change the API in any way.

The opa part will be tested in an upcoming Opa PR. You can test the federation part by rebuilding federation with this branch of authx: in requirements.txt in federation, update to
```
candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@daisieh/renew-idp
```
Rebuild and compose federation.

Update your own federation entry:
```
## add local
curl -X "POST" "http://candig.docker.internal:5080/federation/v1/servers" \
     -H 'Content-Type: application/json' \
     -H 'federation: true' \
     -H 'Authorization: Bearer  <site admin token>' \
     -d $'{
  "server": {
    "id": "internal-1",
    "url": "http://candig.docker.internal:4232/federation",
    "location": {
      "name": "Local UPDATE",
      "province": "ON",
      "province-code": "ca-on"
    }
  },
  "authentication": {
    "token": <site admin token>,
    "issuer": "http://candig.docker.internal:8080/auth/realms/candig"
  }
}'
```

You should see that the servers are updated:
```
## service-info
curl -X "POST" "http://candig.docker.internal:5080/federation/v1/fanout" \
     -H 'Content-Type: application/json' \
     -H 'federation: true' \
     -H 'Authorization: Bearer <site admin token>' \
     -d $'{
  "path": "ga4gh/drs/v1/service-info",
  "payload": {},
  "method": "GET",
  "service": "htsget"
}'
```
will give you "Local UPDATE" for the name of the first server in the result. Really, since no values have really changed, you're just making sure that things still work correctly and federation can still work.