### PR TITLE
DIG-1607: refresh token functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v2.4.3"
+version = "v2.4.4"
 name = "candigv2_authx"
 dependencies = [
     "requests>=2.25.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ minio==7.1.7
 pytest==7.2.0
 PyJWT==2.6.0
 cryptography>=3.4.0
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.0

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -34,7 +34,12 @@ def get_auth_token(request):
     token = request.headers['Authorization']
     if token is None:
         return None
-    return token.split()[1]
+
+    token = token.split()[1]
+    data = jwt.decode(token, options={"verify_signature": False})
+    if data["typ"] == "Refresh":
+        return get_access_token(refresh_token=token)
+    return token
 
 
 def get_oauth_response(

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -86,6 +86,11 @@ def get_access_token(
     refresh_token=None
     ):
 
+    if client_id is None:
+        client_id = get_service_store_secret("keycloak", "client-id")
+    if client_secret is None:
+        client_secret = get_service_store_secret("keycloak", "client-secret")
+
     result = get_oauth_response(
         keycloak_url=keycloak_url,
         client_id=client_id,

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -73,8 +73,6 @@ def get_oauth_response(
     response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
     if response.status_code == 200:
         return response.json()
-    elif response.status_code == 400:
-        return {"error": response.text}
     else:
         raise CandigAuthError(f"Error obtaining access token: {response.text}")
 

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -38,6 +38,7 @@ def get_auth_token(request):
     if token is None:
         return None
 
+    token = token.split(",")[0].strip()
     token = token.split()[1]
     data = jwt.decode(token, options={"verify_signature": False})
     if data["typ"] == "Refresh":

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -6,6 +6,7 @@ import base64
 import json
 import uuid
 import getpass
+from candigv2_logging.logging import CanDIGLogger
 
 
 ## Env vars for most auth methods:
@@ -21,6 +22,8 @@ CANDIG_USER_KEY = os.getenv("CANDIG_USER_KEY", "email")
 ## Env vars for ingest and other site admin tasks:
 CLIENT_ID = os.getenv("CANDIG_CLIENT_ID", None)
 CLIENT_SECRET = os.getenv("CANDIG_CLIENT_SECRET", None)
+
+logger = CanDIGLogger(__file__)
 
 
 class CandigAuthError(Exception):


### PR DESCRIPTION
If this is being executed in a container, look for client secret/client id in the keycloak service store. Also, if the token being processed is a refresh token, exchange it for an access token.

I added a few hooks for logging as well.

This will be tested in https://github.com/CanDIG/CanDIGv2/pull/709.