### PR TITLE
add flexibility for realms

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -22,6 +22,7 @@ CANDIG_USER_KEY = os.getenv("CANDIG_USER_KEY", "email")
 ## Env vars for ingest and other site admin tasks:
 CLIENT_ID = os.getenv("CANDIG_CLIENT_ID", None)
 CLIENT_SECRET = os.getenv("CANDIG_CLIENT_SECRET", None)
+KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "candig")
 
 logger = CanDIGLogger(__file__)
 
@@ -48,6 +49,7 @@ def get_auth_token(request):
 
 def get_oauth_response(
     keycloak_url=KEYCLOAK_PUBLIC_URL,
+    keycloak_realm=KEYCLOAK_REALM,
     client_id=CLIENT_ID,
     client_secret=CLIENT_SECRET,
     username=None,

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -50,6 +50,7 @@ def get_auth_token(request):
 def get_oauth_response(
     keycloak_url=KEYCLOAK_PUBLIC_URL,
     keycloak_realm=KEYCLOAK_REALM,
+    keycloak_realm_url=None,
     client_id=CLIENT_ID,
     client_secret=CLIENT_SECRET,
     username=None,
@@ -81,7 +82,10 @@ def get_oauth_response(
             payload["username"] = username
             payload["password"] = password
 
-    response = requests.post(f"{keycloak_url}/auth/realms/candig/protocol/openid-connect/token", data=payload)
+    url = keycloak_realm_url
+    if url is None:
+        url = f"{keycloak_url}/auth/realms/{keycloak_realm}"
+    response = requests.post(f"{url}/protocol/openid-connect/token", data=payload)
     if response.status_code == 200:
         return response.json()
     else:


### PR DESCRIPTION
If you want to use the authx module to get oauth responses for other domains, you can pass in different values for keycloak_realm_url (perhaps from the `iss` of a jwt) as well as other client secrets/ids.