### PR TITLE
DIG-1560: always call /permissions endpoint for decision log

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -153,13 +153,15 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
         "Authorization": f"Bearer {token}"
     }
     response = requests.post(
-        opa_url + "/v1/data/permissions/datasets",
+        opa_url + "/v1/data/permissions",
         headers=headers,
         json=body
     )
     response.raise_for_status()
-    allowed_datasets = response.json()["result"]
-    return allowed_datasets
+    if "datasets" in response.json()["result"]:
+        return response.json()["result"]["datasets"]
+
+    return []
 
 
 def is_site_admin(request, token=None, opa_url=OPA_URL, admin_secret=None):
@@ -176,7 +178,7 @@ def is_site_admin(request, token=None, opa_url=OPA_URL, admin_secret=None):
         "Authorization": f"Bearer {token}"
     }
     response = requests.post(
-        opa_url + "/v1/data/permissions/site_admin",
+        opa_url + "/v1/data/permissions",
         headers=headers,
         json={
             "input": {
@@ -184,8 +186,8 @@ def is_site_admin(request, token=None, opa_url=OPA_URL, admin_secret=None):
                 }
             }
         )
-    if 'result' in response.json():
-        return True
+    if 'site_admin' in response.json()["result"]:
+        return response.json()["result"]["site_admin"]
     return False
 
 
@@ -200,7 +202,7 @@ def is_action_allowed_for_program(token, method=None, path=None, program=None, o
         "Authorization": f"Bearer {token}"
     }
     response = requests.post(
-        opa_url + "/v1/data/permissions/allowed",
+        opa_url + "/v1/data/permissions",
         headers=headers,
         json={
             "input": {
@@ -213,8 +215,8 @@ def is_action_allowed_for_program(token, method=None, path=None, program=None, o
                 }
             }
         )
-    if 'result' in response.json():
-        return True
+    if 'allowed' in response.json()["result"]:
+        return response.json()["result"]["allowed"]
     return False
 
 


### PR DESCRIPTION
Instead of calling something like OPA_URL/permissions/datasets, call OPA_URL/permissions and then grab the datasets key from that. This way, Opa will log the /permissions call in its decision log and will report all of the extra data at that endpoint.

This is a non-breaking change: all versions of our candig-opa module have the same permissions endpoints available, but present different information in the decision log. Conversely, if a module does not update its version of authx, nothing different should happen either; we just won't record as much information in the decision log.