### PR TITLE
DIG-1666: raise error if bucket does not exist

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -405,10 +405,7 @@ def get_minio_client(token=None, s3_endpoint=None, bucket=None, access_key=None,
         )
 
     if not client.bucket_exists(bucket):
-        if region is None:
-            client.make_bucket(bucket)
-        else:
-            client.make_bucket(bucket, location=region)
+        raise CandigAuthError(f"bucket {bucket} does not exist at {url}")
 
     return {
         "endpoint": endpoint,


### PR DESCRIPTION
We don't want to create buckets as a matter of course in the authx library: we want to return an error if the bucket doesn't exist.

I'm not even sure how to test this anymore: I don't think we use this code very much.