### PR TITLE
DIG-1192: check to see which attribute the request object has

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -145,11 +145,15 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
         "input": {
             "token": token,
             "body": {
-                "path": request.path,
                 "method": request.method
             }
         }
     }
+    if hasattr(request, 'path'):
+        body["input"]["body"]["path"] = request.path
+    elif hasattr(request, 'url'):
+        body["input"]["body"]["path"] = request.url
+
     headers = {
         "Authorization": f"Bearer {token}"
     }


### PR DESCRIPTION
Add the body's input path depending on whether the request object has the "url" attribute or the "path" attribute.

Should act as before. 

To test, run integration tests. Then switch your local copy of authx to this branch, then install that as your working copy:
```
pip install -e <your dir>/candigv2-authx/
```
Then re-run integration tests. They should still pass fine.