### PR TITLE
DIG-1835: response["secure"] is a string but needs to be a bool

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -382,7 +382,7 @@ def get_minio_client(token=None, s3_endpoint=None, bucket=None, access_key=None,
             access_key = response["access_key"]
             secret_key = response["secret_key"]
             url = response["url"]
-            secure = response["secure"]
+            secure = (response["secure"] == "True")
         else:
             endpoint_parse = re.match(r"(https*):\/\/(.+)?", endpoint)
             if endpoint_parse is not None:


### PR DESCRIPTION
While working on setting up the minio server on UHN dev, I realized that there was a sneaky bug in the get_minio_client method in authx. While the s3 credential storing method worked fine, saving `secure=False` for the minio s3 credential, when get_minio_client gets that credential back, it gets the value of `secure` as a string, when it needs to be a bool.

To test:

I've uploaded all of the htsget test files to the dev minio server and they should be accessible anywhere. On your local build, you can go to the small synthetic dataset and replace all of the access methods from `file:////app/htsget_server/data/files/` to `http://candig-demo.uhndata.io:9000/test-genomic/`. Upload the s3 credential to your local ingest by following the instructions here: https://candig.atlassian.net/wiki/spaces/CA/pages/46597893/UHN+Demo+Openstack+Environment#Uploading-genomic-data

Then ingest the small clinical and genomic datasets. They should ingest successfully. You should be able to see the genomic data via the htsget service: 
```
curl "http://candig.docker.internal:5080/genomics/htsget/v1/variants/data/multisample_2" \
     -H 'Authorization: Bearer <site-admin token>'
```