### PR TITLE
DIG-1902: check if user is already authz

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -779,6 +779,9 @@ def add_pending_user_to_opa(user_token):
     if user_name is None:
         return {"error": "Could not verify jwt or obtain user ID"}, 403
 
+    user, status_code = get_user_in_opa(user_name)
+    if status_code != 404:
+        return {"message": f"User {user_name} is already a CanDIG authorized user"}, 200
     user_dict = {
         "userinfo": {
             "user_name": user_name,


### PR DESCRIPTION
Do an extra tiny check: if the user is already a CanDIG-authorized user, return 200 and don't add the user to the pending list.

To test:
Using a site admin token, try adding the site admin to the pending list: 
```
curl -X "POST" "http://candig.docker.internal:5080/ingest/user/pending/request" \
     -H 'Authorization: Bearer <site admin token>'
```
You should get 200 "User site_admin@test.ca is already a CanDIG authorized user"

If you check the pending users list:
```
curl "http://candig.docker.internal:5080/ingest/user/pending" \
     -H 'Authorization: Bearer <site admin token>'
```
the result should not include the site admin.