### PR TITLE
Don't verify jwts; don't allow duplicate tyk entries

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -675,7 +675,7 @@ def decode_token(token, issuer):
     return data
 
 
-def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
+def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID, id=None):
     jwt = decode_token(token, issuer)
     client_id_64 = base64.b64encode(bytes(jwt['azp'], 'utf-8')).decode('utf-8')
     new_provider = {
@@ -684,6 +684,8 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
             client_id_64: policy_id
         }
     }
+    if id is not None:
+        new_provider["id"] = id
     url = f"{TYK_LOGIN_TARGET_URL}/tyk/apis/{api_id}"
     headers = { "x-tyk-authorization": TYK_SECRET_KEY }
     response = requests.request("GET", url, headers=headers)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -689,8 +689,7 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
     response = requests.request("GET", url, headers=headers)
     if response.status_code == 200:
         api_json = response.json()
-        # check to see if it's already here (but not the first one; that's our own provider):
-        for i in range(1, len(api_json['openid_options']['providers'])):
+        for i in range(0, len(api_json['openid_options']['providers'])):
             s = api_json['openid_options']['providers'][i]
             if json.dumps(s, sort_keys=True) == json.dumps(new_provider, sort_keys=True):
                 raise CandigAuthError(f"Provider already in Tyk api {api_id}")
@@ -708,6 +707,7 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
     response = requests.request("GET", url, headers=headers)
     if response.status_code == 200:
         api_json = response.json()
+        # always keep the first one: that's our own provider:
         new_providers = [api_json['openid_options']['providers'].pop(0)]
         for p in api_json['openid_options']['providers']:
             if issuer not in p['issuer']:

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -675,7 +675,7 @@ def decode_token(token, issuer):
     return data
 
 
-def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID, id=None):
+def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
     jwt = decode_token(token, issuer)
     client_id_64 = base64.b64encode(bytes(jwt['azp'], 'utf-8')).decode('utf-8')
     new_provider = {
@@ -684,8 +684,6 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID, id=N
             client_id_64: policy_id
         }
     }
-    if id is not None:
-        new_provider["id"] = id
     url = f"{TYK_LOGIN_TARGET_URL}/tyk/apis/{api_id}"
     headers = { "x-tyk-authorization": TYK_SECRET_KEY }
     response = requests.request("GET", url, headers=headers)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -692,15 +692,11 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID, id=N
     if response.status_code == 200:
         api_json = response.json()
         # check to see if it's already here:
-        found = False
         for i in range(0, len(api_json['openid_options']['providers'])):
             s = api_json['openid_options']['providers'][i]
             if json.dumps(s, sort_keys=True) == json.dumps(new_provider, sort_keys=True):
-                found = True
-                api_json['openid_options']['providers'][i] = new_provider
-                break
-        if not found:
-            api_json['openid_options']['providers'].append(new_provider)
+                raise CandigAuthError(f"Provider already in Tyk api {api_id}")
+        api_json['openid_options']['providers'].append(new_provider)
         response = requests.request("PUT", url, headers=headers, json=api_json)
         if response.status_code == 200:
             response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -689,8 +689,8 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
     response = requests.request("GET", url, headers=headers)
     if response.status_code == 200:
         api_json = response.json()
-        # check to see if it's already here:
-        for i in range(0, len(api_json['openid_options']['providers'])):
+        # check to see if it's already here (but not the first one; that's our own provider):
+        for i in range(1, len(api_json['openid_options']['providers'])):
             s = api_json['openid_options']['providers'][i]
             if json.dumps(s, sort_keys=True) == json.dumps(new_provider, sort_keys=True):
                 raise CandigAuthError(f"Provider already in Tyk api {api_id}")

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -692,7 +692,7 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
         for i in range(0, len(api_json['openid_options']['providers'])):
             s = api_json['openid_options']['providers'][i]
             if json.dumps(s, sort_keys=True) == json.dumps(new_provider, sort_keys=True):
-                raise CandigAuthError(f"Provider already in Tyk api {api_id}")
+                return None
         api_json['openid_options']['providers'].append(new_provider)
         response = requests.request("PUT", url, headers=headers, json=api_json)
         if response.status_code == 200:

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -708,7 +708,7 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
     response = requests.request("GET", url, headers=headers)
     if response.status_code == 200:
         api_json = response.json()
-        new_providers = [api_json['openid_options']['providers'].pop()]
+        new_providers = [api_json['openid_options']['providers'].pop(0)]
         for p in api_json['openid_options']['providers']:
             if issuer not in p['issuer']:
                 new_providers.append(p)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -708,7 +708,7 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
     response = requests.request("GET", url, headers=headers)
     if response.status_code == 200:
         api_json = response.json()
-        new_providers = []
+        new_providers = [api_json['openid_options']['providers'].pop()]
         for p in api_json['openid_options']['providers']:
             if issuer not in p['issuer']:
                 new_providers.append(p)

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -666,8 +666,17 @@ def decode_verify_token(token, issuer):
     return None
 
 
+def decode_token(token, issuer):
+    # the token is a valid CanDIG token from the new server: it contains its issuer and audience
+    data = jwt.decode(token, options={"verify_signature": False})
+    if data['iss'] != issuer:
+        raise CandigAuthError(f"The token's iss ({data['iss']}) does not match the issuer ({issuer})")
+
+    return data
+
+
 def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
-    jwt = decode_verify_token(token, issuer)
+    jwt = decode_token(token, issuer)
     client_id_64 = base64.b64encode(bytes(jwt['azp'], 'utf-8')).decode('utf-8')
     new_provider = {
         "issuer": jwt['iss'],
@@ -722,7 +731,7 @@ def remove_provider_from_tyk_api(api_id, issuer, policy_id=TYK_POLICY_ID):
 
 def add_provider_to_opa(token, issuer, test_key=None):
     new_provider = None
-    jwt = decode_verify_token(token, issuer)
+    jwt = decode_token(token, issuer)
     jwks_response = requests.get(f"{jwt['iss']}/.well-known/openid-configuration")
     if jwks_response.status_code == 200:
         jwks_response = requests.get(jwks_response.json()["jwks_uri"])


### PR DESCRIPTION
1) Don't verify the jwts for adding providers to tyk and opa: just decode them
2) When looking at tyk providers, always keep the first one because that's our own server that we put in during tyk setup
3) But if the provider to be added matches one that is already in there, don't add it again.