### PR TITLE
Throw an exception on an invalid token

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -177,6 +177,14 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
         headers=headers,
         json=body
     )
+
+    # Test: what the heck is happening
+    logger.debug(f"response looks like: {response.json()}")
+
+    # Ensure that the token is valid before continuing
+    if "result" in response.json() and "valid_token" in response.json()["result"] and not response.json()["result"]["valid_token"]:
+        raise Exception("Invalid token")
+
     if response.status_code == 200:
         if "datasets" in response.json()["result"]:
             return response.json()["result"]["datasets"]

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -184,7 +184,7 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
     # or one that looks like {"result":{"valid_token": false, ...} ...}
     if "unauthorized" == response.json().get("code", "") or \
         not response.json().get("result", {}).get("valid_token", True):
-        raise Exception("Invalid token")
+        raise CandigAuthError("Invalid token")
 
     if response.status_code == 200:
         if "datasets" in response.json()["result"]:

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -178,11 +178,12 @@ def get_opa_datasets(request, opa_url=OPA_URL, admin_secret=None):
         json=body
     )
 
-    # Test: what the heck is happening
-    logger.debug(f"response looks like: {response.json()}")
-
     # Ensure that the token is valid before continuing
-    if "result" in response.json() and "valid_token" in response.json()["result"] and not response.json()["result"]["valid_token"]:
+    # Note that there's two possible responses from OPA here: either a dictionary
+    # that looks like {'code': 'unauthorized', 'message': 'request rejected by administrative policy'}
+    # or one that looks like {"result":{"valid_token": false, ...} ...}
+    if "unauthorized" == response.json().get("code", "") or \
+        not response.json().get("result", {}).get("valid_token", True):
         raise Exception("Invalid token")
 
     if response.status_code == 200:


### PR DESCRIPTION
[Jira ticket](https://candig.atlassian.net/browse/DIG-2070)

This PR causes `get_opa_datasets` to throw an exception when an expired token is given, rather than silently returning an empty array. This will help downstream services differentiate between "this user is valid but has no datasets authorized for them" vs "this token I got made no sense".