### PR TITLE
Fix a bug where multiple clients with the same issuer was buggy

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -782,6 +782,7 @@ def add_provider_to_opa(token, issuer, test_key=None):
                             found = False # not the same because they have different test keys
                 if found:
                     # replace with the new provider data
+                    new_provider['aud'] = list(set(new_provider['aud']).union(set(s['aud'])))
                     response["keys"][i] = new_provider
                     break
         if not found:

--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -697,6 +697,7 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
             client_id_64: policy_id
         }
     }
+    previous_provider = None
     url = f"{TYK_LOGIN_TARGET_URL}/tyk/apis/{api_id}"
     headers = { "x-tyk-authorization": TYK_SECRET_KEY }
     response = requests.request("GET", url, headers=headers)
@@ -706,7 +707,17 @@ def add_provider_to_tyk_api(api_id, token, issuer, policy_id=TYK_POLICY_ID):
             s = api_json['openid_options']['providers'][i]
             if json.dumps(s, sort_keys=True) == json.dumps(new_provider, sort_keys=True):
                 return None
-        api_json['openid_options']['providers'].append(new_provider)
+
+            # If we have another provider with the same issuer, just add this client ID to it
+            # Note that if we instead added a second provider with the same issuer, it will not work
+            if s['issuer'] == jwt['iss']:
+                previous_provider = s
+                previous_provider['client_ids'][client_id_64] = policy_id
+                break
+
+        # Add a new provider if this issuer doesn't yet exist
+        if not previous_provider:
+            api_json['openid_options']['providers'].append(new_provider)
         response = requests.request("PUT", url, headers=headers, json=api_json)
         if response.status_code == 200:
             response = requests.request("GET", f"{TYK_LOGIN_TARGET_URL}/tyk/reload", params={"block": True}, headers=headers)


### PR DESCRIPTION
Fixes a bug uncovered in the DHDP where multiple clients being added with the same issuer was ignoring everything except the first entry.

# To Test

Tested with candig-demo by the following:

1. Create a new client in the candig realm with client authentication enabled
<img width="1480" height="716" alt="image" src="https://github.com/user-attachments/assets/30570658-d06e-45f6-b1cf-593e7a757dfb" />
2. Copy over the client secret
<img width="1480" height="716" alt="image" src="https://github.com/user-attachments/assets/d5b652fa-0835-4375-ae07-d9ddec70fdc6" />
3. With the client scope, edit the dedicated scope for the new client
<img width="1480" height="716" alt="image" src="https://github.com/user-attachments/assets/42ca9fba-5523-474f-b37c-834a363df71c" />
4. Add a dedicated audience mapper
<img width="1480" height="716" alt="image" src="https://github.com/user-attachments/assets/cdb155df-2c2b-4235-972a-29dbc324ed2d" />
5.Add the client to its own audience
<img width="1480" height="716" alt="image" src="https://github.com/user-attachments/assets/32f66125-4929-40b7-b63f-7250eea4c9f6" />

Finally configure your .env to put you on the same Keycloak instance

```
(candig) 14:19 fnguyen@fnguyen-worktop:~/Documents/CanDIGv2$ diff .env etc/env/example.env
5c5
< CANDIG_MODULES=logging vault redis postgres htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
---
> CANDIG_MODULES=logging keycloak vault redis postgres htsget katsu rnaget query tyk opa federation candig-ingest candig-data-portal
7,8c7,8
< CANDIG_AUTH_MODULES=vault tyk opa federation
< CANDIG_DATA_MODULES=vault redis postgres logging
---
> CANDIG_AUTH_MODULES=keycloak vault tyk opa federation
> CANDIG_DATA_MODULES=keycloak vault redis postgres logging
13c13
< CANDIG_AUTH_DOMAIN=candigauth-demo.uhndata.io
---
> CANDIG_AUTH_DOMAIN=candig.docker.internal
166c166
< KEYCLOAK_CLIENT_ID=test-client
---
> KEYCLOAK_CLIENT_ID=local_candig
170,173c170,173
< KEYCLOAK_PUBLIC_PROTO=https
< KEYCLOAK_PRIVATE_PROTO=https
< KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_PROTO}://${CANDIG_AUTH_DOMAIN}
< KEYCLOAK_PRIVATE_URL=${KEYCLOAK_PRIVATE_PROTO}://${CANDIG_AUTH_DOMAIN}
---
> KEYCLOAK_PUBLIC_PROTO=http
> KEYCLOAK_PRIVATE_PROTO=http
> KEYCLOAK_PUBLIC_URL=${KEYCLOAK_PUBLIC_PROTO}://${CANDIG_AUTH_DOMAIN}:${KEYCLOAK_PORT}
> KEYCLOAK_PRIVATE_URL=${KEYCLOAK_PRIVATE_PROTO}://${CANDIG_AUTH_DOMAIN}:${KEYCLOAK_PORT}
```