### PR TITLE
update opa as well

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -782,6 +782,7 @@ def add_provider_to_opa(token, issuer, test_key=None):
                             found = False # not the same because they have different test keys
                 if found:
                     # replace with the new provider data
+                    new_provider['aud'] = list(set(new_provider['aud']).union(set(s['aud'])))
                     response["keys"][i] = new_provider
                     break
         if not found:


### PR DESCRIPTION
Update to #50: Opa also needs a parallel fix: if it saves the issuer twice, but with two different sets of aud values, it will fail to evaluate the rego. Maybe? I'm not sure that I can reproduce this error if https://github.com/CanDIG/CanDIGv2/pull/1128 is used, but I think that it certainly can't hurt to clean up this code.