### PR TITLE
Add client credentials grant

### DIFF
--- a/src/authx/auth.py
+++ b/src/authx/auth.py
@@ -65,7 +65,8 @@ def get_oauth_response(
     client_secret=CLIENT_SECRET,
     username=None,
     password=None,
-    refresh_token=None
+    refresh_token=None,
+    client_account=False
     ):
     """
     Gets a token from the keycloak server.
@@ -84,6 +85,8 @@ def get_oauth_response(
     if refresh_token is not None:
         payload["refresh_token"] = refresh_token
         payload["grant_type"] = "refresh_token"
+    elif client_account:
+        payload["grant_type"] = "client_credentials"
     else:
         if username is None or password is None:
             raise CandigAuthError("Username and password required for token")


### PR DESCRIPTION
# Description
This allows get_oauth_response to be used for the client credentials grant if the new keyword `client_account=True`. This will then use the given client ID and secret to obtain a token, rather than anything else.

This is meant to be used in conjunction with https://github.com/CanDIG/CanDIGv2/pull/1133