### PR TITLE
Update requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,15 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-version = "v2.8.7"
+version = "v2.9.1"
 name = "candigv2_authx"
 dependencies = [
-    "requests>=2.32.2",
+    "requests>=2.33.1",
     "minio>=7.2.19",
-    "pytest>=8.3.3",
-    "PyJWT>=2.6.0",
-    "cryptography>=43.0.1"
+    "pytest>=9.0.3",
+    "PyJWT>=2.12.0"
     ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.12"
 description = "Common authentication and authorization methods for CanDIGv2"
 readme = "README.md"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.33.1
 minio==7.2.19
 pytest>=9.0.3
-PyJWT>=2.12.0
+PyJWT>=2.13.0
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-requests==2.32.4
-minio==7.2.12
-pytest==8.3.3
-PyJWT==2.12.0
-cryptography>=43.0.1
-candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1
+requests>=2.33.1
+minio==7.2.19
+pytest>=9.0.3
+PyJWT>=2.12.0
+candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.4


### PR DESCRIPTION
Also removed unused cryptography module.

I tested by rebuilding my stack with this branch referenced in the etc/venv/requirements.txt and in ingest and htsget’s requirements, and ran integration tests. They worked fine.